### PR TITLE
ログイン関連

### DIFF
--- a/api/common/handler/response.go
+++ b/api/common/handler/response.go
@@ -12,17 +12,17 @@ import (
 
 func ResponseOKPagination(c *gin.Context, data any, paginatedResponse *PaginatedResponse) {
 	if data == nil {
-		c.JSON(http.StatusOK, gin.H{"result": "OK"})
+		c.JSON(http.StatusOK, gin.H{"ok": true})
 	} else {
-		c.JSON(http.StatusOK, gin.H{"result": "OK", "data": data, "pagination": paginatedResponse})
+		c.JSON(http.StatusOK, gin.H{"ok": true, "data": data, "pagination": paginatedResponse})
 	}
 }
 
 func ResponseOK(c *gin.Context, data any) {
 	if data == nil {
-		c.JSON(http.StatusOK, gin.H{"result": "OK"})
+		c.JSON(http.StatusOK, gin.H{"ok": true})
 	} else {
-		c.JSON(http.StatusOK, gin.H{"result": "OK", "data": data})
+		c.JSON(http.StatusOK, gin.H{"ok": true, "data": data})
 	}
 }
 
@@ -40,7 +40,7 @@ func ResponseError(c *gin.Context, status int, msg string, err error) {
 	}
 	slog.WarnContext(c, msg)
 
-	c.JSON(status, gin.H{"result": "Error", "data": msg})
+	c.JSON(status, gin.H{"ok": false, "data": msg})
 }
 
 func ResponseNotFound(c *gin.Context, msg string, err error) {

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,6 +4,7 @@ go 1.22.9
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/gin-contrib/cors v1.7.2
 	github.com/gin-gonic/gin v1.10.0
 	github.com/oklog/ulid/v2 v2.1.0
 	golang.org/x/crypto v0.23.0
@@ -26,6 +27,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -6,6 +6,7 @@ github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -15,6 +16,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
+github.com/gin-contrib/cors v1.7.2 h1:oLDHxdg8W/XDoN/8zamqk/Drgt4oVZDvaV0YmvVICQw=
+github.com/gin-contrib/cors v1.7.2/go.mod h1:SUJVARKgQ40dmrzgXEVxj2m7Ig1v1qIboQkPDTQ9t2E=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=
@@ -44,6 +47,10 @@ github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.2.7 h1:ZWSB3igEs+d0qvnxR/ZBzXVmxkgt8DdzP6m9pfuVLDM=
 github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -64,6 +71,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
+github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -101,8 +110,9 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IV
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
 google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/api/main.go
+++ b/api/main.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 
 	"github.com/jcytp/kifup-api/common/db"
@@ -25,6 +26,12 @@ func main() {
 
 	r := gin.Default()
 	if gin.Mode() == gin.DebugMode {
+		config := cors.DefaultConfig()
+		config.AllowOrigins = []string{"http://192.168.11.12:8081"} // frontend開発サーバー
+		config.AllowMethods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
+		config.AllowHeaders = []string{"Origin", "Content-Type", "Authorization"}
+		r.Use(cors.New(config))
+
 		r.Static("/swagger", "./swagger")
 	}
 
@@ -48,11 +55,12 @@ func main() {
 	rs := rp.Group("/")
 	rs.Use(handler.MwRequireSession)
 	{
+		rs.GET("/account", handler.HandlerOut(api.GetAccount))
 		rs.DELETE("/account", handler.Handler(api.DeleteAccount))
 		rs.PUT("/account/password", handler.HandlerIn(api.ChangePassword))
 		rs.POST("/session/refresh", handler.HandlerOut(api.RefreshSession))
 
-		// ToDo: manage kifu, manage account, etc.
+		// ToDo: manage kifu, etc.
 	}
 
 	r.Run() // default -> localhost:8080

--- a/api/service/api/account.go
+++ b/api/service/api/account.go
@@ -36,6 +36,15 @@ func CreateAccount(c *gin.Context, req requestCreateAccount) (string, error) {
 	return "", nil
 }
 
+func GetAccount(c *gin.Context) (*model.AccountResponse, string, error) {
+	aid := handler.GetAccountID(c)
+	account, err := dao.GetAccountByID(aid)
+	if err != nil {
+		return nil, "Failed to get account", err
+	}
+	return account.ToResponse(), "", nil
+}
+
 func DeleteAccount(c *gin.Context) (string, error) {
 	aid := handler.GetAccountID(c)
 

--- a/api/service/dao/accounts.go
+++ b/api/service/dao/accounts.go
@@ -49,7 +49,7 @@ func InsertAccount(account *model.Account) (string, error) {
 			id, name, email, pass_hash,
 			icon_id, introduction,
 			created_at, last_login_at
-		) VALUES (?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	_, err := db.Exec(
 		query,

--- a/api/service/model/Account.go
+++ b/api/service/model/Account.go
@@ -26,7 +26,7 @@ type AccountResponse struct {
 	IconID       string    `json:"icon_id"`
 	Introduction string    `json:"introduction"`
 	CreatedAt    time.Time `json:"created_at"`
-	LastLoginAt  time.Time `db:"last_login_at"`
+	LastLoginAt  time.Time `json:"last_login_at"`
 }
 
 func (t *Account) ToResponse() *AccountResponse {

--- a/api/swagger/api.yml
+++ b/api/swagger/api.yml
@@ -28,6 +28,20 @@ paths:
         '500':
           description: Server error
           $ref: '#/components/responses/ErrorResponse'
+    get:
+      summary: アカウント情報の取得
+      tags: [Account]
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          $ref: '#/components/responses/AccountResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          description: Server error
+          $ref: '#/components/responses/ErrorResponse'
     delete:
       summary: アカウント削除
       tags: [Account]
@@ -116,11 +130,11 @@ components:
       content:
         application/json:
           schema:
-          type: object
-          properties:
-            result:
-              type: string
-              example: OK
+            type: object
+            properties:
+              ok:
+                type: boolean
+                example: true
     ErrorResponse:
       description: エラーレスポンス
       content:
@@ -128,9 +142,9 @@ components:
           schema:
             type: object
             properties:
-              result:
-                type: string
-                example: "Error"
+              ok:
+                type: boolean
+                example: false
               data:
                 type: string
                 example: "some error occurred"
@@ -141,12 +155,39 @@ components:
           schema:
             type: object
             properties:
-              result:
-                type: string
-                example: "OK"
+              ok:
+                type: boolean
+                example: false
               data:
                 type: string
                 example: "eyJhbGciOiJIUzI1NiIs..."
+    AccountResponse:
+      description: アカウント情報取得成功
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              ok:
+                type: boolean
+                example: false
+              data:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  icon_id:
+                    type: string
+                  introduction:
+                    type: string
+                  created_at:
+                    type: string
+                    format: date-time
+                  last_login_at:
+                    type: string
+                    format: date-time
   schemas:
     CreateAccountRequest:
       type: object

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -3,6 +3,9 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+		<link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap" rel="stylesheet">
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>

--- a/frontend/src/lib/api/account.ts
+++ b/frontend/src/lib/api/account.ts
@@ -1,0 +1,30 @@
+import { API, type ApiResult } from '$lib/classes/API';
+import { account } from '$lib/stores/session';
+import type { Account } from '$lib/types/Account';
+
+export const Register = async (
+	name: string,
+	email: string,
+	password: string
+): Promise<ApiResult> => {
+	const params = {
+		name: name,
+		email: email,
+		password: password
+	};
+	const result = await API.post('/api/account', params, false);
+	return result;
+};
+
+export const GetAccount = async (): Promise<ApiResult> => {
+	const result = await API.get('/api/account', null, true);
+	if (!result.data) {
+		console.error('get account error: no data');
+		result.ok = false;
+		result.data = 'アカウント情報の取得に失敗しました。';
+	}
+	if (result.ok) {
+        account.set(result.data as Account)
+	}
+	return result;
+};

--- a/frontend/src/lib/api/session.ts
+++ b/frontend/src/lib/api/session.ts
@@ -1,0 +1,20 @@
+import { API, type ApiResult } from '$lib/classes/API';
+import { token } from '$lib/stores/session';
+
+export const Login = async (email: string, password: string): Promise<ApiResult> => {
+	const params = {
+		email: email,
+		password: password
+	};
+	const result = await API.post('/api/session/login', params, false);
+	if (!result.data) {
+		console.error('login error: no data');
+		result.ok = false;
+		result.data = 'ログインに失敗しました。';
+	}
+	if (result.ok) {
+		token.set(result.data)
+		// ToDO: refreshAccountInfo
+	}
+	return result;
+};

--- a/frontend/src/lib/classes/API.ts
+++ b/frontend/src/lib/classes/API.ts
@@ -1,0 +1,68 @@
+// src/lib/classes/API.ts
+
+import { token } from "$lib/stores/session";
+import { get } from 'svelte/store';
+
+export interface ApiResult {
+    ok: boolean;
+    data?: any;
+}
+
+export class API {
+    static server = 'http://192.168.11.12:8080'; // 開発サーバー
+
+    static async get(path: string, params: any, withToken=true): Promise<ApiResult> {
+        const url = this.server + path;
+        const headers: any = {};
+        if (withToken) {
+            const currentToken = get(token);
+            if (currentToken) {
+                headers['Authorization'] = `Bearer ${currentToken}`;
+            } else {
+                return {ok: false, data: 'no token error'}
+            }
+        }
+        const response = await fetch(url, {
+            method: 'GET',
+            // mode: 'same-origin', // 開発サーバーではoriginが異なる
+            cache: 'no-cache',
+            headers: headers,
+        });
+        if (!response.ok) {
+            return {
+                ok: false,
+                data: `${response.status}: ${response.statusText}`,
+            };
+        }
+        return await response.json();
+    }
+
+    static async post(path: string, params: any, withToken=true): Promise<ApiResult> {
+        const url = this.server + path;
+        const headers: any = {
+            'Content-Type': 'application/json',
+        };
+        if (withToken) {
+            const currentToken = get(token);
+            if (currentToken) {
+                headers['Authorization'] = `Bearer ${currentToken}`;
+            } else {
+                return {ok: false, data: 'no token error'}
+            }
+        }
+        const response = await fetch(url, {
+            method: 'POST',
+            // mode: 'same-origin', // 開発サーバーではoriginが異なる
+            cache: 'no-cache',
+            headers: headers,
+            body: JSON.stringify(params),
+        });
+        if (!response.ok) {
+            return {
+                ok: false,
+                data: `${response.status}: ${response.statusText}`,
+            };
+        }
+        return await response.json();
+    }
+}

--- a/frontend/src/lib/stores/session.ts
+++ b/frontend/src/lib/stores/session.ts
@@ -1,0 +1,34 @@
+// src/lib/stores/session.ts
+
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+import type { Account } from '$lib/types/Account';
+
+const createTokenStore = () => {
+    const initialValue = browser ? localStorage.getItem('token') : null;
+    const { subscribe, set } = writable<string | null>(initialValue);
+    const token = {
+        subscribe,
+        set: (token: string | null) => {
+            // if (browser) {
+                if (token) {
+                    localStorage.setItem('token', token);
+                } else {
+                    localStorage.removeItem('token');
+                }
+            // }
+            set(token);
+        },
+        clear: () => {
+            // if (browser) {
+                localStorage.removeItem('token');
+            // }
+            set(null);
+        }
+    };
+    return token;
+}
+
+export const token = createTokenStore();
+
+export const account = writable<Account | null>(null);

--- a/frontend/src/lib/styles/default.scss
+++ b/frontend/src/lib/styles/default.scss
@@ -3,33 +3,24 @@
 @import './reset.scss';
 
 :root {
-  --primary-color: #2c5282;
-  --secondary-color: #4299e1;
-  --background-color: #f7fafc;
-  --text-color: #2d3748;
-  --border-color: #e2e8f0;
+  // main color
+  --primary-color: #557153;    /* 深い抹茶色：ヘッダー、重要ボタン */
+  --secondary-color: #7D8F69;  /* 明るい抹茶色：ナビゲーション、セクション見出し */
+
+  // functional color
+  --background-color: #F8FFF2; /* 淡い若葉色：背景 */
+  --text-color: #1F2A1B;      /* 濃い緑：テキスト */
+  --border-color: #C8D4BC;    /* 柔らかい抹茶色：ボーダー */
+
+  --z-index-header: 100;
+  --z-index-nav: 90;
 }
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: 'Kosugi Maru', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background-color: var(--background-color);
   color: var(--text-color);
-}
-
-.app {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
-main {
-  flex: 1;
-  padding: 2rem;
-  max-width: 1200px;
-  margin: 0 auto;
-  width: 100%;
-  box-sizing: border-box;
 }
 
 button {

--- a/frontend/src/lib/types/Account.ts
+++ b/frontend/src/lib/types/Account.ts
@@ -3,6 +3,10 @@
 export interface Account {
 	id: string;
 	name: string;
-	email: string;
+	icon_id?: string;
+	introduction?: string;
+	email?: string;
+	created_at: Date;
+	last_login_at: Date;
 }
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -2,14 +2,44 @@
 
 <script lang="ts">
 	import '$lib/styles/default.scss';
-  import { getContext } from 'svelte';
-  import type { Account } from '$lib/types/Account';
+  import { onMount } from 'svelte';
+	import { account, token } from '$lib/stores/session';
+	import { goto } from '$app/navigation';
+	import { GetAccount } from '$lib/api/account';
+	import type { Account } from '$lib/types/Account';
 
-  // Account context
-  const account = getContext<Account | null>('account');
+  // ロード時にLocalStorageのトークンを取得
+  onMount(async () => {
+    const currentToken = localStorage.getItem('token');
+    if (currentToken) {
+      token.set(currentToken);
+    }
+  })
 
-  // $: isLoggedIn = !!account;
-  $: isLoggedIn = true;
+  // トークンが更新された場合
+  $: if ($token) {
+    // アカウント情報を取得
+    (async () => {
+      const result = await GetAccount()
+      if (result.ok) {
+        const new_account = result.data as Account;
+        account.set(new_account);
+      } else {
+        // アカウント情報を取得できなかった場合、トークンを削除
+        token.clear();
+      }
+    })();
+  } else {
+    // トークンが削除された場合（ログアウト時）は、トップページへ遷移
+    account.set(null);
+    goto('/');
+  }
+
+  $: isLoggedIn = !!$account;
+
+  const logout = () => {
+    token.clear();
+  }
 </script>
 
 <div class="app">
@@ -23,7 +53,7 @@
         <li><a href="/kifu/new">新規作成</a></li>
         <li><a href="/kifu/search">棋譜検索</a></li>
         <li><a href="/settings">設定</a></li>
-        <li><button class="logout">ログアウト</button></li>
+        <li class="newgroup"><button on:click={logout}>ログアウト</button></li>
       {:else}
         <li><a href="/">ログイン</a></li>
         <li><a href="/kifu/search">棋譜検索</a></li>
@@ -34,64 +64,91 @@
     <slot />
   </main>
   <footer>
-    <p>©曹操オッキマラ 2024 kifup</p>
+    <p>©jcytp 2024 kifup</p>
   </footer>
 </div>
 
 <style lang="scss">
-  header {
-    background-color: var(--primary-color);
-    padding: 1rem;
+  .app {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
 
-    .logo {
-      color: white;
-      text-decoration: none;
-      font-size: 1.5rem;
-      font-weight: bold;
-    }
-  }
+    header {
+      background-color: var(--background-color);
+      border-bottom: 0.3rem var(--primary-color) solid;
+      padding: 0.5rem 0 0rem 11rem;
+      z-index: var(--z-index-header);
 
-  nav {
-    background-color: var(--secondary-color);
-    padding: 0.5rem;
-
-    ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: flex;
-      gap: 1rem;
-    }
-
-    a {
-      color: white;
-      text-decoration: none;
-      padding: 0.5rem 1rem;
-
-      &:hover {
-        background-color: rgba(255, 255, 255, 0.1);
-        border-radius: 4px;
+      .logo {
+        color: var(--primary-color);
+        text-decoration: none;
+        font-size: 1.7rem;
+        font-weight: bold;
+        line-height: 2.7rem;
       }
     }
 
-    .logout {
-      background: none;
-      border: 1px solid white;
-      color: white;
-      padding: 0.5rem 1rem;
-      cursor: pointer;
-      border-radius: 4px;
+    nav {
+      position: fixed;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      z-index: var(--z-index-nav);
+      background-color: var(--background-color);
+      padding: 6rem 0.5rem 4rem 0.5rem;
+      overflow-y: auto;
 
-      &:hover {
-        background-color: rgba(255, 255, 255, 0.1);
+      ul {
+        display: flex;
+        flex-direction: column;
+        list-style: none;
+        gap: 0.5rem;
+
+        li a,
+        li button {
+          display: block;
+          width: 9rem;
+          padding-left: 1rem;
+          line-height: 2rem;
+          color: var(--primary-color);
+          text-decoration: none;
+          text-align: left;
+
+          &:hover {
+            background-color: var(--secondary-color);
+            border-radius: 0.5rem;
+            color: var(--background-color);
+          }
+        }
+
+        li.newgroup {
+          margin-top: 0.5rem;
+          border-top: var(--border-color) 1px solid;
+          padding-top: 1rem;
+        }
       }
     }
-  }
 
-  footer {
-    background-color: var(--primary-color);
-    color: white;
-    padding: 1rem;
-    text-align: center;
+    main {
+      flex: 1;
+      padding: 2rem 0 2rem 10rem;
+      max-width: 1200px;
+      width: 100%;
+      box-sizing: border-box;
+    }
+
+    footer {
+      border-top: var(--primary-color) 0.2rem solid;
+      background-color: var(--background-color);
+      color: var(--primary-color);
+      padding: 0.2rem 0 0.8rem 11rem;
+      z-index: var(--z-index-header);
+      
+        p {
+          font-size: 1rem;
+          line-height: 2rem;
+        }
+    }
   }
 </style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,186 +1,352 @@
 <!-- src/routes/+page.svelte -->
 
 <script lang="ts">
-  let loginForm = {
-    email: '',
-    password: ''
-  };
+	import { goto } from '$app/navigation';
+	import { Register } from '$lib/api/account';
+	import { Login } from '$lib/api/session';
+  import { account } from '$lib/stores/session';
 
-  let registerForm = {
-    name: '',
-    email: '',
-    password: '',
-    passwordConfirm: ''
-  };
-
-  function handleLogin() {
-    // ToDo: ログイン処理
-    console.log('Login:', loginForm);
+  // ログイン済みの場合はホームへ遷移する
+  $: if ($account) {
+    goto('/home');
   }
 
-  function handleRegister() {
-    // ToDo: 新規登録処理
-    console.log('Register:', registerForm);
-  }
+	// フォーム表示の状態管理
+	let activeSection: 'login' | 'register' | 'reset' = 'login';
+	let errorMessage = '';
+
+	// 各フォームの入力値
+	let loginForm = {
+		email: '',
+		password: ''
+	};
+	let registerForm = {
+		name: '',
+		email: '',
+		password: '',
+		passwordConfirm: ''
+	};
+	let resetForm = {
+		email: ''
+	};
+
+	// フォームの切り替え
+	const switchToLogin = () => {
+		activeSection = 'login';
+		errorMessage = '';
+	};
+	const switchToRegister = () => {
+		activeSection = 'register';
+		errorMessage = '';
+	};
+	const switchToReset = () => {
+		activeSection = 'reset';
+		errorMessage = '';
+	};
+
+	const handleLogin = async () => {
+		const result = await Login(loginForm.email, loginForm.password);
+		if (!result.ok) {
+			errorMessage = 'ログイン処理中にエラーが発生しました';
+			return;
+		}
+		goto('/home');
+	}
+
+	const handleRegister = async () => {
+		console.debug('handleRegister');
+		if (registerForm.password !== registerForm.passwordConfirm) {
+			errorMessage = 'パスワードが一致していません';
+			console.debug(errorMessage);
+			return;
+		}
+		const result = await Register(registerForm.name, registerForm.email, registerForm.password);
+		if (!result.ok) {
+			errorMessage = '新規登録処理中にエラーが発生しました';
+			return;
+		}
+		const result_login = await Login(registerForm.email, registerForm.password);
+		if (!result_login.ok) {
+			errorMessage = 'ログイン処理中にエラーが発生しました';
+			return;
+		}
+		goto('/home');
+	};
+
+	function handleReset() {
+		// ToDo: パスワードリセット処理
+		console.log('Reset:', resetForm);
+	}
 </script>
 
 <div class="top">
-  <section class="login">
-    <h2>ログイン</h2>
-    <form on:submit|preventDefault={handleLogin}>
-      <div class="form-group">
-        <label for="login-email">メールアドレス</label>
-        <input
-          type="email"
-          id="login-email"
-          bind:value={loginForm.email}
-          required
-        />
-      </div>
-      <div class="form-group">
-        <label for="login-password">パスワード</label>
-        <input
-          type="password"
-          id="login-password"
-          bind:value={loginForm.password}
-          required
-        />
-      </div>
-      <button type="submit">ログイン</button>
-    </form>
-  </section>
+	{#if activeSection === 'login'}
+		<section class="form-section">
+			<form on:submit|preventDefault={handleLogin}>
+				<h2>ログイン</h2>
+				<div class="form-group">
+					<label for="login-email">メールアドレス</label>
+					<input
+						type="email"
+						id="login-email"
+						bind:value={loginForm.email}
+						autocomplete="email"
+						required
+					/>
+				</div>
+				<div class="form-group">
+					<label for="login-password">パスワード</label>
+					<input
+						type="password"
+						id="login-password"
+						bind:value={loginForm.password}
+						autocomplete="current-password"
+						required
+					/>
+				</div>
+				<button type="submit">ログイン</button>
+				{#if errorMessage}
+					<div class="error-message">
+						{errorMessage}
+					</div>
+				{/if}
+			</form>
+			<ul class="view-control">
+				<li><button on:click={switchToRegister}>新規登録</button></li>
+				<li><button on:click={switchToReset}>パスワードを忘れた</button></li>
+			</ul>
+		</section>
+	{/if}
 
-  <section class="register">
-    <h2>新規登録</h2>
-    <form on:submit|preventDefault={handleRegister}>
-      <div class="form-group">
-        <label for="register-name">名前</label>
-        <input
-          type="text"
-          id="register-name"
-          bind:value={registerForm.name}
-          required
-        />
-      </div>
-      <div class="form-group">
-        <label for="register-email">メールアドレス</label>
-        <input
-          type="email"
-          id="register-email"
-          bind:value={registerForm.email}
-          required
-        />
-      </div>
-      <div class="form-group">
-        <label for="register-password">パスワード</label>
-        <input
-          type="password"
-          id="register-password"
-          bind:value={registerForm.password}
-          required
-        />
-      </div>
-      <div class="form-group">
-        <label for="register-password-confirm">パスワード（確認）</label>
-        <input
-          type="password"
-          id="register-password-confirm"
-          bind:value={registerForm.passwordConfirm}
-          required
-        />
-      </div>
-      <button type="submit">登録</button>
-    </form>
-  </section>
+	{#if activeSection === 'register'}
+		<section class="form-section">
+			<form on:submit|preventDefault={handleRegister}>
+				<h2>新規登録</h2>
+				<div class="form-group">
+					<label for="register-name">名前</label>
+					<input
+						type="text"
+						id="register-name"
+						bind:value={registerForm.name}
+						autocomplete="nickname"
+						required
+					/>
+				</div>
+				<div class="form-group">
+					<label for="register-email">メールアドレス</label>
+					<input
+						type="email"
+						id="register-email"
+						bind:value={registerForm.email}
+						autocomplete="email"
+						required
+					/>
+				</div>
+				<div class="form-group">
+					<label for="register-password">パスワード</label>
+					<input
+						type="password"
+						id="register-password"
+						bind:value={registerForm.password}
+						autocomplete="new-password"
+						required
+					/>
+				</div>
+				<div class="form-group">
+					<label for="register-password-confirm">パスワード（確認）</label>
+					<input
+						type="password"
+						id="register-password-confirm"
+						bind:value={registerForm.passwordConfirm}
+						autocomplete="off"
+						required
+					/>
+				</div>
+				<button type="submit">登録</button>
+				{#if errorMessage}
+					<div class="error-message">
+						{errorMessage}
+					</div>
+				{/if}
+			</form>
+			<ul class="view-control">
+				<li><button on:click={switchToLogin}>ログイン</button></li>
+			</ul>
+		</section>
+	{/if}
 
-  <section class="about">
-    <h2>kifupとは？</h2>
-    <p>
-      kifupは、将棋の棋譜を管理・共有するためのWebアプリケーションです。
-      対局の記録を保存し、振り返りや研究に活用できます。
-    </p>
-    <div class="features">
-      <div class="feature">
-        <h3>棋譜の管理</h3>
-        <p>棋譜を簡単にアップロードし、整理できます。</p>
-      </div>
-      <div class="feature">
-        <h3>対局の再生</h3>
-        <p>保存した棋譜を再生して、局面を確認できます。</p>
-      </div>
-      <div class="feature">
-        <h3>コミュニティ</h3>
-        <p>他のユーザーと棋譜を共有し、コメントを交換できます。</p>
-      </div>
-    </div>
-  </section>
+	{#if activeSection === 'reset'}
+		<section class="form-section">
+			<form on:submit|preventDefault={handleReset}>
+				<h2>パスワードの再設定</h2>
+				<div class="form-group">
+					<label for="reset-email">メールアドレス</label>
+					<input
+						type="email"
+						id="reset-email"
+						bind:value={resetForm.email}
+						autocomplete="email"
+						required
+					/>
+				</div>
+				<button type="submit">送信</button>
+				{#if errorMessage}
+					<div class="error-message">
+						{errorMessage}
+					</div>
+				{/if}
+			</form>
+			<ul class="view-control">
+				<li><button on:click={switchToLogin}>ログイン</button></li>
+				<li><button on:click={switchToRegister}>新規登録</button></li>
+			</ul>
+		</section>
+	{/if}
+
+	<section class="feature-section">
+		<h2>kifupとは？</h2>
+		<p>
+			kifupは、将棋の棋譜を管理・共有するためのWebアプリケーションです。
+			対局の記録を保存し、振り返りや研究に活用できます。
+		</p>
+		<div class="features">
+			<div class="feature">
+				<h3>棋譜の管理</h3>
+				<p>棋譜を簡単にアップロードし、整理できます。</p>
+			</div>
+			<div class="feature">
+				<h3>対局の再生</h3>
+				<p>保存した棋譜を再生して、局面を確認できます。</p>
+			</div>
+			<div class="feature">
+				<h3>棋譜の共有</h3>
+				<p>棋譜にコメントを付けて、共有リンクで公開できます。</p>
+			</div>
+		</div>
+	</section>
 </div>
 
+<!-- ToDo: @media (min-width: 780px) -->
+
 <style>
-  .top {
-    display: grid;
-    gap: 2rem;
-  }
+	.top {
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
 
-  section {
-    background: white;
-    padding: 2rem;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  }
+		.form-section {
+			display: flex;
 
-  .form-group {
-    margin-bottom: 1rem;
-  }
+			form {
+				width: 70%;
+				background: white;
+				border: 0.1rem solid var(--secondary-color);
+				padding: 1rem 2rem 2rem 2rem;
+				border-radius: 1rem;
 
-  label {
-    display: block;
-    margin-bottom: 0.5rem;
-    color: var(--text-color);
-  }
+				h2 {
+					color: var(--secondary-color);
+					font-size: 1.4rem;
+					line-height: 2rem;
+					margin-bottom: 1rem;
+				}
 
-  input {
-    width: 100%;
-    padding: 0.5rem;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    box-sizing: border-box;
-  }
+				.form-group {
+					margin-top: 1rem;
 
-  button {
-    background-color: var(--primary-color);
-    color: white;
-    padding: 0.5rem 1rem;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    width: 100%;
-  }
+					label {
+						display: block;
+						margin-bottom: 0.5rem;
+					}
 
-  button:hover {
-    background-color: var(--secondary-color);
-  }
+					input {
+						width: 100%;
+						padding: 0.5rem 0.5rem;
+						border: 1px solid var(--border-color);
+						border-radius: 0.5rem;
+						box-sizing: border-box;
+						background: var(--background-color);
 
-  .features {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1rem;
-    margin-top: 1rem;
-  }
+						&:focus {
+							background-color: white;
+						}
+					}
+				}
 
-  .feature {
-    padding: 1rem;
-    background-color: var(--background-color);
-    border-radius: 4px;
-  }
+				button {
+					margin-top: 1.5rem;
+					background-color: var(--primary-color);
+					color: var(--background-color);
+					padding: 0.5rem 1rem;
+					border: none;
+					border-radius: 0.5rem;
+					width: 100%;
 
-  @media (min-width: 768px) {
-    .top {
-      grid-template-columns: repeat(2, 1fr);
-    }
+					&:hover {
+						background-color: var(--secondary-color);
+					}
+				}
 
-    .about {
-      grid-column: 1 / -1;
-    }
-  }
+				.error-message {
+					color: #dc2626;
+					padding: 0.5rem;
+					font-size: small;
+					text-align: center;
+				}
+			}
+
+			ul.view-control {
+				display: flex;
+				flex-direction: column;
+				justify-content: end;
+				gap: 0.5rem;
+				width: 30%;
+				padding: 0.5rem 1rem;
+
+				button {
+					background: var(--background-color);
+					padding: 0.3rem 1rem;
+					border: 1px solid var(--secondary-color);
+					border-radius: 0.5rem;
+					width: 100%;
+
+					&:hover {
+						background-color: var(--secondary-color);
+						color: var(--background-color);
+					}
+				}
+			}
+		}
+
+		.feature-section {
+			margin-top: 1rem;
+			border-top: 0.2rem solid var(--primary-color);
+			padding: 1rem;
+
+			h2 {
+				color: var(--secondary-color);
+				font-size: 1.4rem;
+				line-height: 2rem;
+				margin-bottom: 1rem;
+			}
+
+			.features {
+				display: grid;
+				grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+				gap: 1rem;
+				margin-top: 1rem;
+
+				.feature {
+					background: #fff;
+					padding: 1rem;
+					border-radius: 0.5rem;
+					box-shadow: 0 0.1rem 0.4rem #999;
+
+					h3 {
+						margin-bottom: 0.5rem;
+					}
+				}
+			}
+		}
+	}
 </style>


### PR DESCRIPTION
- APIレスポンスの標準構造を、string型のresultからboolean型のokに変更
- レイアウトのUIを変更し、抹茶系カラーで左メニューに（モバイル対応は後回し）
- トップページのUIを変更し、ログイン/新規登録/パスワードリセットを表示切り替え方式に
- frontendにて簡易的なユーザー登録とログインを実装
- ログイン時、セッショントークンをLocalStorageに保存しアカウント情報を取得
- ログアウト時、トークンとアカウント情報を削除
- 開発環境に合わせてCORS許可を設定