### PR TITLE
棋譜管理のAPIエンドポイントを作成

### DIFF
--- a/api/common/auxi/auxiliary.go
+++ b/api/common/auxi/auxiliary.go
@@ -1,3 +1,5 @@
+// common/auxi/auxiliary.go
+
 package auxi
 
 import (
@@ -23,4 +25,17 @@ func PInt64(i int64) *int64 {
 
 func PBool(b bool) *bool {
 	return &b
+}
+
+func PString(s string) *string {
+	return &s
+}
+
+func IsInArray[T comparable](val T, arr []T) bool {
+	for _, v := range arr {
+		if val == v {
+			return true
+		}
+	}
+	return false
 }

--- a/api/common/handler/pagination.go
+++ b/api/common/handler/pagination.go
@@ -5,24 +5,28 @@ package handler
 import "math"
 
 type PaginationRequest struct {
-	Page  int `form:"page,default=1" binding:"min=1"`
-	Limit int `form:"limit,default=10" binding:"min=1,max=100"`
+	Page     int `form:"page,default=1" binding:"min=1"`
+	PageSize int `form:"page_size,default=20" binding:"min=1,max=100"`
 }
 
 type PaginatedResponse struct {
 	TotalCount int `json:"total_count"`
 	Page       int `json:"page"`
-	Limit      int `json:"limit"`
+	PageSize   int `json:"page_size"`
 	MaxPage    int `json:"max_page"`
 }
 
-func NewPaginatedResponse(req *PaginationRequest, totalCount int) *PaginatedResponse {
-	maxPage := int(math.Max(1, math.Ceil(float64(totalCount)/float64(req.Limit))))
+func (req *PaginationRequest) LimitOffset() (int, int) {
+	return req.PageSize, req.PageSize * (req.Page - 1)
+}
+
+func (req *PaginationRequest) NewPaginatedResponse(totalCount int) *PaginatedResponse {
+	maxPage := int(math.Max(1, math.Ceil(float64(totalCount)/float64(req.PageSize))))
 
 	return &PaginatedResponse{
 		TotalCount: totalCount,
 		Page:       req.Page,
-		Limit:      req.Limit,
+		PageSize:   req.PageSize,
 		MaxPage:    maxPage,
 	}
 }

--- a/api/main.go
+++ b/api/main.go
@@ -48,7 +48,8 @@ func main() {
 	rp := ra.Group("/")
 	rp.Use(handler.MwCheckSession)
 	{
-		// ToDo: search kifu, etc.
+		rp.GET("/kifu", handler.HandlerInPagination(api.ListKifus))
+		rp.GET("/kifu/:kifuID", handler.HandlerOut(api.GetKifu))
 	}
 
 	// require session
@@ -60,7 +61,10 @@ func main() {
 		rs.PUT("/account/password", handler.HandlerIn(api.ChangePassword))
 		rs.POST("/session/refresh", handler.HandlerOut(api.RefreshSession))
 
-		// ToDo: manage kifu, etc.
+		rs.POST("/kifu", handler.HandlerInOut(api.CreateKifu))
+		rs.DELETE("/kifu/:kifuID", handler.Handler(api.DeleteKifu))
+		rs.PUT("/kifu/:kifuID", handler.HandlerIn(api.UpdateKifuInfo))
+		rs.PUT("/kifu/:kifuID/moves", handler.HandlerIn(api.UpdateKifuMoves))
 	}
 
 	r.Run() // default -> localhost:8080

--- a/api/service/api/kifu.go
+++ b/api/service/api/kifu.go
@@ -1,0 +1,393 @@
+// service/api/kifu.go
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jcytp/kifup-api/common/auxi"
+	"github.com/jcytp/kifup-api/common/handler"
+	"github.com/jcytp/kifup-api/service/dao"
+	"github.com/jcytp/kifup-api/service/model"
+)
+
+// ------------------------------------------------------------
+type requestCreateKifu struct {
+	Type            string  `json:"type" binding:"required,oneof=file position"`
+	Content         *string `json:"content,omitempty" binding:"required_if=Type file"`
+	InitialPosition *string `json:"initial_position,omitempty"`
+}
+
+func CreateKifu(c *gin.Context, req requestCreateKifu) (*string, string, error) {
+	aid := handler.GetAccountID(c)
+
+	switch req.Type {
+	case "file":
+		return createKifuFromFile(aid, *req.Content)
+	case "position":
+		return createKifuFromPosition(aid, (*model.SFEN)(req.InitialPosition))
+	default:
+		return nil, "Invalid creation type", fmt.Errorf("invalid type: %s", req.Type)
+	}
+}
+
+func createKifuFromFile(aid string, content string) (*string, string, error) {
+	_ = aid
+	_ = content
+	// 1. 棋譜フォーマットごとに棋譜テキストをパースする
+	// 　※どの棋譜フォーマットにも合致しなければエラー
+	// 2. 生成されたKifu・KifuOption・KifuBranch・KifuMoveをDBに保存する
+	return nil, "Not implemented", fmt.Errorf("createKifuFromFile request")
+}
+
+func createKifuFromPosition(aid string, sfen *model.SFEN) (*string, string, error) {
+	// SFENの妥当性チェック
+	_, err := model.NewBoardPosition(sfen)
+	if err != nil {
+		return nil, "Invalid initial position", err
+	}
+
+	// 棋譜レコードを作成
+	kifu := &model.Kifu{
+		AccountID:       aid,
+		Title:           "新規棋譜",
+		IsPublic:        false,
+		InitialPosition: sfen,
+	}
+	kifuID, err := dao.InsertKifu(kifu)
+	if err != nil {
+		return nil, "Failed to create kifu", err
+	}
+
+	// メインラインの空branchを作成
+	branch := &model.KifuBranch{
+		KifuID: kifuID,
+	}
+	_, err = dao.InsertKifuBranch(branch)
+	if err != nil {
+		return nil, "Failed to create branch", err
+	}
+
+	return &kifuID, "", nil
+}
+
+// ------------------------------------------------------------
+type requestListKifus struct {
+	Owner *string `form:"owner"`
+}
+
+func ListKifus(c *gin.Context, req requestListKifus, pgreq *handler.PaginationRequest) (*[]*model.KifuSummaryResponse, *handler.PaginatedResponse, string, error) {
+	limit, offset := pgreq.LimitOffset()
+
+	// ownerに応じてKifuリストを取得
+	var totalCount int
+	var kifus []*model.Kifu
+	var err error
+	if req.Owner == nil {
+		totalCount, _ = dao.CountPublicKifus()
+		kifus, err = dao.ListPublicKifus(limit, offset) // 公開棋譜リスト
+	} else {
+		if *req.Owner == "me" {
+			accountID := handler.GetAccountID(c)
+			totalCount, _ = dao.CountKifusByAccountID(accountID)
+			kifus, err = dao.ListKifusByAccountID(accountID, limit, offset) // 自身の棋譜リスト
+		} else {
+			totalCount, _ = dao.CountPublicKifusByAccountID(*req.Owner)
+			kifus, err = dao.ListPublicKifusByAccountID(*req.Owner, limit, offset) // 特定アカウントの公開棋譜リスト
+		}
+	}
+	if err != nil {
+		return nil, nil, "Failed to get kifu list", err
+	}
+
+	// レスポンス構築
+	responses := make([]*model.KifuSummaryResponse, 0, len(kifus))
+	for _, kifu := range kifus {
+		owner, err := dao.GetAccountByID(kifu.AccountID)
+		if err != nil {
+			return nil, nil, "Failed to get account info", err
+		}
+		tags, err := dao.ListKifuTagsByKifuID(kifu.ID)
+		if err != nil {
+			return nil, nil, "Failed to get tags", err
+		}
+		response := kifu.ToSummaryResponse(owner, tags)
+		responses = append(responses, response)
+	}
+	return &responses, pgreq.NewPaginatedResponse(totalCount), "", nil
+}
+
+// ------------------------------------------------------------
+func GetKifu(c *gin.Context) (*model.KifuDetailResponse, string, error) {
+	accountID := handler.GetAccountID(c)
+	kifuID := c.GetString("kifuID")
+
+	kifu, err := dao.GetKifu(kifuID)
+	if err != nil {
+		return nil, "Failed to get kifu", err
+	}
+
+	// 非公開の棋譜は所有者のみアクセス可能
+	if !kifu.IsPublic && (accountID != kifu.AccountID) {
+		return nil, "Access denied", fmt.Errorf("unauthorized acces to private kifu")
+	}
+
+	owner, err := dao.GetAccountByID(kifu.AccountID)
+	if err != nil {
+		return nil, "Failed to get account info", err
+	}
+	options, err := dao.ListKifuOptionsByKifuID(kifuID)
+	if err != nil {
+		return nil, "Failed to get kifu options", err
+	}
+	tags, err := dao.ListKifuTagsByKifuID(kifuID)
+	if err != nil {
+		return nil, "Failed to get kifu tags", err
+	}
+	branches, err := dao.ListKifuBranchesByKifuID(kifuID)
+	if err != nil {
+		return nil, "Failed to get branches", err
+	}
+	branchesWithMoves := make([]*model.KifuBranchWithMoves, 0, len(branches))
+	for _, branch := range branches {
+		moves, err := dao.ListKifuMovesByBranchID(branch.ID)
+		if err != nil {
+			return nil, "Failed to get moves", err
+		}
+		branchWithMoves := &model.KifuBranchWithMoves{
+			KifuBranch: branch,
+			Moves:      moves,
+		}
+		branchesWithMoves = append(branchesWithMoves, branchWithMoves)
+	}
+
+	response := kifu.ToDetailResponse(owner, options, tags, branchesWithMoves)
+	return response, "", nil
+}
+
+// ------------------------------------------------------------
+func DeleteKifu(c *gin.Context) (string, error) {
+	accountID := handler.GetAccountID(c)
+	kifuID := c.GetString("kifuID")
+
+	// 存在確認と所有者チェック
+	kifu, err := dao.GetKifu(kifuID)
+	if err != nil {
+		return "Failed to get kifu", err
+	}
+	if kifu.AccountID != accountID {
+		return "Access denied", fmt.Errorf("unauthorized access")
+	}
+
+	// 棋譜の削除
+	err = dao.DeleteKifu(kifuID, accountID)
+	if err != nil {
+		return "Failed to delete kifu", err
+	}
+
+	return "", nil
+}
+
+// ------------------------------------------------------------
+type requestUpdateKifuInfo struct {
+	Title    string         `json:"title" binding:"required"`
+	IsPublic bool           `json:"is_public"`
+	GameInfo model.GameInfo `json:"game_info"` // 対局情報（black_player, white_player, started_at, time_rule, その他オプション）
+	Tags     []string       `json:"tags"`      // タグリスト
+}
+
+func UpdateKifuInfo(c *gin.Context, req requestUpdateKifuInfo) (string, error) {
+	accountID := handler.GetAccountID(c)
+	kifuID := c.GetString("kifuID")
+
+	// 存在確認と所有者チェック
+	kifu, err := dao.GetKifu(kifuID)
+	if err != nil {
+		return "Failed to get kifu", err
+	}
+	if kifu.AccountID != accountID {
+		return "Access denied", fmt.Errorf("unauthorized access")
+	}
+
+	// Kifu更新
+	kifu.Title = req.Title
+	kifu.IsPublic = req.IsPublic
+	kifu.BlackPlayer = req.GameInfo.GetBlackPlayer()
+	kifu.WhitePlayer = req.GameInfo.GetWhitePlayer()
+	kifu.StartedAt = req.GameInfo.GetStartedAt()
+	kifu.TimeRule = req.GameInfo.GetTimeRule()
+
+	err = dao.UpdateKifu(kifu)
+	if err != nil {
+		return "Failed to update kifu", err
+	}
+
+	// KifuOption更新
+	if err := dao.ClearKifuOptionsByKifuID(kifuID); err != nil {
+		return "Failed to clear existing kifu options", err
+	}
+
+	reservedKeys := []string{"先手", "後手", "対局日時", "持ち時間", "秒読み", "秒加算"}
+	options := make([]*model.KifuOption, 0, len(req.GameInfo))
+	for k, v := range req.GameInfo {
+		if auxi.IsInArray(k, reservedKeys) {
+			continue
+		}
+		options = append(options, &model.KifuOption{
+			KifuID: kifuID,
+			Name:   k,
+			Value:  v,
+		})
+	}
+	if err := dao.InsertKifuOptions(options); err != nil {
+		return "Failed to insert kifu options", err
+	}
+
+	// KifuTag更新
+	if err := dao.ClearKifuTagsByKifuID(kifuID); err != nil {
+		return "Failed to clear existing kifu tags", err
+	}
+
+	tags := make([]*model.KifuTag, 0, len(req.Tags))
+	for _, name := range req.Tags {
+		tags = append(tags, &model.KifuTag{
+			KifuID: kifuID,
+			Name:   name,
+		})
+	}
+	if err := dao.InsertKifuTags(tags); err != nil {
+		return "Failed to insert kifu tags", err
+	}
+
+	return "", nil
+}
+
+// ------------------------------------------------------------
+type KifuMoveRequest struct {
+	Number        int64                  `json:"number"`                   // 何手目か（分岐の場合も初手からカウント）
+	Piece         model.PieceType        `json:"piece"`                    // 動いた元の駒種
+	FromPlace     model.PiecePlace       `json:"from_place"`               // 移動元の場所
+	ToPlace       model.PiecePlace       `json:"to_place"`                 // 移動先の場所
+	Promote       *bool                  `json:"promote,omitempty"`        // 成ったか（成らなければNULL）
+	CatchPiece    *model.PieceType       `json:"catch_piece,omitempty"`    // 取った駒種（取ってなければNULL）
+	DirectionSign *string                `json:"direction_sign,omitempty"` // 方向の符号（無ければNULL）
+	Variations    *[]KifuMoveLineRequest `json:"variations,omitempty"`     // この手に変わる分岐
+	Comment       *string                `json:"comment"`                  // コメント
+	TimeSpentMs   *int64                 `json:"time_spent_ms"`            // 消費時間（ミリ秒）
+}
+
+type KifuMoveLineRequest []*KifuMoveRequest
+
+func (move *KifuMoveRequest) ToKifuMove(branchID string) *model.KifuMove {
+	return &model.KifuMove{
+		BranchID:    branchID,
+		Number:      move.Number,
+		Piece:       move.Piece,
+		FromPlace:   move.FromPlace,
+		ToPlace:     move.ToPlace,
+		Comment:     move.Comment,
+		TimeSpentMs: move.TimeSpentMs,
+	}
+}
+
+type requestUpdateKifuMoves struct {
+	Moves KifuMoveLineRequest `json:"moves"` // メインラインと分岐を含む指し手情報
+}
+
+func UpdateKifuMoves(c *gin.Context, req requestUpdateKifuMoves) (string, error) {
+	accountID := handler.GetAccountID(c)
+	kifuID := c.GetString("kifuID")
+
+	// 存在確認と所有者チェック
+	kifu, err := dao.GetKifu(kifuID)
+	if err != nil {
+		return "Failed to get kifu", err
+	}
+	if kifu.AccountID != accountID {
+		return "Access denied", fmt.Errorf("unauthorized access")
+	}
+
+	// 既存データの削除
+	if err := dao.ClearKifuBranchesByKifuID(kifuID); err != nil {
+		return "Failed to clear existing branches", err
+	}
+
+	// 初期局面の生成（整合性チェックに使用）
+	position, err := model.NewBoardPosition(kifu.InitialPosition)
+	if err != nil {
+		return "Invalid initial position", err
+	}
+
+	// ブランチの保存（IDの取得）と指し手の生成のための全体リスト
+	branchWithMovesList := []*model.KifuBranchWithMoves{}
+
+	// メインブランチを保存して全体リストに追加
+	mainBranch := &model.KifuBranch{KifuID: kifuID}
+	mainBranchID, err := dao.InsertKifuBranch(mainBranch)
+	if err != nil {
+		return "Failed to insert kifu branch", err
+	}
+	mainBranch.ID = mainBranchID
+	mainBranchWithMoves := &model.KifuBranchWithMoves{
+		KifuBranch: mainBranch,
+		Moves:      []*model.KifuMove{},
+	}
+	branchWithMovesList = append(branchWithMovesList, mainBranchWithMoves)
+
+	// メインブランチから再帰的にブランチの保存と指し手の生成
+	if msg, err := createBranchWithMovesRecursive(kifuID, &branchWithMovesList, req.Moves, mainBranchWithMoves, position); err != nil {
+		return msg, err
+	}
+
+	// 指し手の保存
+	for _, branchWithMoves := range branchWithMovesList {
+		if err := dao.InsertKifuMoves(branchWithMoves.Moves); err != nil {
+			return "Failed to insert branch", err
+		}
+	}
+
+	return "", nil
+}
+
+// ブランチに対する指し手生成の再帰処理
+func createBranchWithMovesRecursive(kifuID string, branchWithMovesList *[]*model.KifuBranchWithMoves, moves KifuMoveLineRequest, currentBranchWithMoves *model.KifuBranchWithMoves, position *model.BoardPosition) (string, error) {
+	for _, move := range moves {
+		// 指し手の整合性チェック
+		kifuMove := move.ToKifuMove(currentBranchWithMoves.ID)
+		if err := position.Move(kifuMove); err != nil {
+			return "Invalid move", err
+		}
+
+		// 分岐の処理
+		if move.Variations != nil {
+			for _, variation := range *move.Variations {
+				// variationに対してブランチを作成し、再帰処理を呼び出す
+				newBranch := &model.KifuBranch{
+					KifuID:       kifuID,
+					RootBranchID: &currentBranchWithMoves.ID,
+					RootNumber:   &move.Number,
+				}
+				newBranchID, err := dao.InsertKifuBranch(newBranch)
+				if err != nil {
+					return "Failed to insert kifu branch", err
+				}
+				newBranch.ID = newBranchID
+				newBranchWithMoves := &model.KifuBranchWithMoves{
+					KifuBranch: newBranch,
+					Moves:      []*model.KifuMove{},
+				}
+				(*branchWithMovesList) = append((*branchWithMovesList), newBranchWithMoves) // 全体リストに新ブランチを追加
+
+				// 再帰呼び出し
+				if msg, err := createBranchWithMovesRecursive(kifuID, branchWithMovesList, variation, newBranchWithMoves, position.Copy()); err != nil {
+					return msg, err
+				}
+			}
+		}
+
+		// 指し手の追加
+		currentBranchWithMoves.Moves = append(currentBranchWithMoves.Moves, move.ToKifuMove(currentBranchWithMoves.ID))
+	}
+	return "", nil
+}

--- a/api/service/api/setup.go
+++ b/api/service/api/setup.go
@@ -19,9 +19,6 @@ func SetupTables() {
 	if err := dao.CreateKifuTagTable(); err != nil {
 		log.Fatal()
 	}
-	if err := dao.CreateKifuInitialPieceTable(); err != nil {
-		log.Fatal()
-	}
 	if err := dao.CreateKifuBranchTable(); err != nil {
 		log.Fatal()
 	}

--- a/api/service/dao/kifu_branches.go
+++ b/api/service/dao/kifu_branches.go
@@ -59,14 +59,20 @@ func InsertKifuBranch(branch *model.KifuBranch) (string, error) {
 	return branch.ID, err
 }
 
-func DeleteKifuBranch(branchID string, kifuID string) error {
-	query := `DELETE FROM kifu_branches WHERE id = ? AND kifu_id = ?`
-	res, err := db.Exec(query, branchID, kifuID)
-	if err != nil {
-		return err
-	}
-	return db.CheckAffectedRows(res, 1)
+func ClearKifuBranchesByKifuID(kifuID string) error {
+	query := `DELETE FROM kifu_branches WHERE kifu_id = ?`
+	_, err := db.Exec(query, kifuID)
+	return err
 }
+
+// func DeleteKifuBranch(branchID string, kifuID string) error {
+// 	query := `DELETE FROM kifu_branches WHERE id = ? AND kifu_id = ?`
+// 	res, err := db.Exec(query, branchID, kifuID)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return db.CheckAffectedRows(res, 1)
+// }
 
 func ListKifuBranchesByKifuID(kifuID string) ([]*model.KifuBranch, error) {
 	query := `

--- a/api/service/dao/kifu_options.go
+++ b/api/service/dao/kifu_options.go
@@ -48,26 +48,10 @@ func InsertKifuOptions(options []*model.KifuOption) error {
 	return nil
 }
 
-func UpdateKifuOption(option *model.KifuOption) error {
-	query := `
-		UPDATE kifu_options 
-		SET value = ?
-		WHERE kifu_id = ? AND name = ?
-	`
-	res, err := db.Exec(query, option.Value, option.KifuID, option.Name)
-	if err != nil {
-		return err
-	}
-	return db.CheckAffectedRows(res, 1)
-}
-
-func DeleteKifuOption(kifuID string, name string) error {
-	query := `DELETE FROM kifu_options WHERE kifu_id = ? AND name = ?`
-	res, err := db.Exec(query, kifuID, name)
-	if err != nil {
-		return err
-	}
-	return db.CheckAffectedRows(res, 1)
+func ClearKifuOptionsByKifuID(kifuID string) error {
+	query := `DELETE FROM kifu_options WHERE kifu_id = ?`
+	_, err := db.Exec(query, kifuID)
+	return err
 }
 
 func ListKifuOptionsByKifuID(kifuID string) ([]*model.KifuOption, error) {

--- a/api/service/dao/kifu_tags.go
+++ b/api/service/dao/kifu_tags.go
@@ -47,13 +47,10 @@ func InsertKifuTags(tags []*model.KifuTag) error {
 	return nil
 }
 
-func DeleteKifuTag(kifuID string, name string) error {
-	query := `DELETE FROM kifu_tags WHERE kifu_id = ? AND name = ?`
-	res, err := db.Exec(query, kifuID, name)
-	if err != nil {
-		return err
-	}
-	return db.CheckAffectedRows(res, 1)
+func ClearKifuTagsByKifuID(kifuID string) error {
+	query := `DELETE FROM kifu_tags WHERE kifu_id = ?`
+	_, err := db.Exec(query, kifuID)
+	return err
 }
 
 func ListKifuTagsByKifuID(kifuID string) ([]*model.KifuTag, error) {

--- a/api/service/dao/kifus.go
+++ b/api/service/dao/kifus.go
@@ -121,7 +121,19 @@ func GetKifu(kifuID string) (*model.Kifu, error) {
 	return kifu, nil
 }
 
-func GetKifusByAccountID(accountID string, limit int, offset int) ([]*model.Kifu, error) {
+func CountKifusByAccountID(accountID string) (int, error) {
+	query := `
+		SELECT COUNT(*) FROM kifus
+		WHERE account_id = ?
+	`
+	var count int
+	if err := db.QueryRow(query, accountID).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func ListKifusByAccountID(accountID string, limit int, offset int) ([]*model.Kifu, error) {
 	query := `
 		SELECT * FROM kifus
 		WHERE account_id = ?
@@ -149,6 +161,18 @@ func GetKifusByAccountID(accountID string, limit int, offset int) ([]*model.Kifu
 		kifus = append(kifus, kifu)
 	}
 	return kifus, nil
+}
+
+func CountPublicKifus() (int, error) {
+	query := `
+		SELECT COUNT(*) FROM kifus
+		WHERE is_public = true 
+	`
+	var count int
+	if err := db.QueryRow(query).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func ListPublicKifus(limit int, offset int) ([]*model.Kifu, error) {
@@ -179,6 +203,18 @@ func ListPublicKifus(limit int, offset int) ([]*model.Kifu, error) {
 		kifus = append(kifus, kifu)
 	}
 	return kifus, nil
+}
+
+func CountPublicKifusByAccountID(accountID string) (int, error) {
+	query := `
+		SELECT COUNT(*) FROM kifus
+		WHERE is_public = true AND account_id = ?
+	`
+	var count int
+	if err := db.QueryRow(query, accountID).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func ListPublicKifusByAccountID(accountID string, limit int, offset int) ([]*model.Kifu, error) {

--- a/api/service/model/Kifu.go
+++ b/api/service/model/Kifu.go
@@ -17,7 +17,7 @@ type Kifu struct {
 	WhitePlayer     *string         `db:"white_player"`     // 後手の名前
 	StartedAt       *time.Time      `db:"started_at"`       // 開始日時
 	TimeRule        *TimeRuleString `db:"time_rule"`        // 持ち時間
-	InitialPosition *SFEN           `db:"initial_position"` // 開始局面
+	InitialPosition *SFEN           `db:"initial_position"` // 開始局面（平手初期局面はNULL）
 	CreatedAt       time.Time       `db:"created_at"`
 	UpdatedAt       time.Time       `db:"updated_at"`
 }
@@ -58,6 +58,6 @@ type KifuMove struct {
 }
 
 type KifuBranchWithMoves struct {
-	KifuBranch
+	*KifuBranch
 	Moves []*KifuMove
 }

--- a/api/service/model/KifuMoveResponse.go
+++ b/api/service/model/KifuMoveResponse.go
@@ -71,9 +71,7 @@ func (t *Kifu) buildMoves(branches []*KifuBranchWithMoves) KifuMoveLineResponse 
 
 	// メインラインを特定（RootBranchIDがnullのもの）
 	var mainBranch *KifuBranchWithMoves
-	branchMap := map[string]*KifuBranchWithMoves{}
 	for _, branch := range branches {
-		branchMap[branch.ID] = branch
 		if branch.RootBranchID == nil {
 			mainBranch = branch
 		}


### PR DESCRIPTION
棋譜管理のAPIエンドポイントを作成
- GET /api/kifu ... 公開棋譜一覧を取得
- GET /api/kifu?owner=me ... 自身の棋譜一覧を取得
- GET /api/kifu?owner={accountID} ... 指定ユーザーの公開棋譜一覧を取得
- GET /api/kifu/{kifuID} ... 棋譜の詳細取得
- POST /api/kifu ... 棋譜の新規作成
- DELETE /api/kifu/{kifuID} ... 棋譜の削除
- PUT /api/kifu/{kifuID} ... 棋譜情報の編集
- PUT /api/kifu/{kifuID}/moves ... 棋譜の指し手の編集