### PR TITLE
get and show kifu list

### DIFF
--- a/frontend/src/lib/apis/kifu.ts
+++ b/frontend/src/lib/apis/kifu.ts
@@ -1,0 +1,93 @@
+// src/lib/apis/kifu.ts
+
+import { API, type ApiResult } from '$lib/types/API';
+import type { KifuMove } from '$lib/types/Kifu';
+
+export const searchKifus = async (
+  owner: string | null,
+  page: number,
+  page_size: number,
+  isLoggedIn: boolean
+): Promise<ApiResult> => {
+  const params = {
+    owner: owner,
+    page: page,
+    page_size: page_size,
+  };
+  const result = await API.get('/api/kifu', params, isLoggedIn);
+  if (!result.data) {
+    console.error('search kifus error: no data');
+    result.ok = false;
+    result.data = '棋譜リストの取得に失敗しました。';
+  }
+  return result;
+};
+
+export const createKifu = async (
+  type: 'file' | 'position',
+  content?: string,
+  initialPosition?: string
+): Promise<ApiResult> => {
+  const params = {
+    type: type,
+    content: content,
+    initial_position: initialPosition,
+  };
+  const result = await API.post('/api/kifu', params, true);
+  if (!result.data) {
+    console.error('create kifu error: no data');
+    result.ok = false;
+    result.data = '棋譜の作成に失敗しました。';
+  }
+  return result;
+};
+
+export const getKifu = async (kifuId: string): Promise<ApiResult> => {
+  const result = await API.get(`/api/kifu/${kifuId}`, null, true);
+  if (!result.data) {
+    console.error('get kifu error: no data');
+    result.ok = false;
+    result.data = '棋譜の取得に失敗しました。';
+  }
+  return result;
+};
+
+export const deleteKifu = async (kifuId: string): Promise<ApiResult> => {
+  const result = await API.delete(`/api/kifu/${kifuId}`, null, true);
+  if (!result.ok) {
+    console.error('delete kifu error');
+    result.data = '棋譜の削除に失敗しました。';
+  }
+  return result;
+};
+
+export const updateKifuInfo = async (
+  kifuId: string,
+  title: string,
+  isPublic: boolean,
+  gameInfo: { [key: string]: string },
+  tags: string[]
+): Promise<ApiResult> => {
+  const params = {
+    title,
+    is_public: isPublic,
+    game_info: gameInfo,
+    tags,
+  };
+  const result = await API.put(`/api/kifu/${kifuId}`, params, true);
+  if (!result.ok) {
+    console.error('update kifu info error');
+    result.data = '棋譜情報の更新に失敗しました。';
+  }
+  return result;
+};
+
+export const updateKifuMoves = async (kifuId: string, moves: KifuMove[]): Promise<ApiResult> => {
+  const params = { moves };
+  const result = await API.put(`/api/kifu/${kifuId}/moves`, params, true);
+  if (!result.ok) {
+    console.error('update kifu moves error');
+    result.data = '棋譜の指し手の更新に失敗しました。';
+  }
+  return result;
+};

--- a/frontend/src/lib/components/KifuList.svelte
+++ b/frontend/src/lib/components/KifuList.svelte
@@ -1,0 +1,271 @@
+<!-- src/lib/components/KifuList.svelte -->
+
+<script lang="ts">
+  import type { PaginationResponse } from '$lib/types/API';
+  import type { KifuSummary } from '$lib/types/Kifu';
+
+  // Callback functions
+  export let changePage: (page: number) => Promise<void>;
+  export let togglePublic: (kifu: KifuSummary) => Promise<void> = async (kifu: KifuSummary) => {};
+  export let deleteKifu: (kifuId: string) => Promise<void> = async (kifuId: string) => {};
+
+  // Props
+  export let kifuList: KifuSummary[] = [];
+  export let pagination: PaginationResponse | null = null;
+  export let loading = false;
+  export let mode: 'view-only' | 'with-actions' = 'view-only';
+
+  // 選択中の棋譜ID（アクション表示用）
+  let selectedKifuId: string | null = null;
+
+  // ページ変更ハンドラ
+  function handleChangePage(page: number) {
+    if (pagination && page >= 1 && page <= pagination.max_page) {
+      changePage(page);
+      selectedKifuId = null; // ページ変更時にポップアップを閉じる
+    }
+  }
+
+  // イベントハンドラ（MouseEventとKeyboardEventの両方に対応）
+  function handleCardClick(event: MouseEvent | KeyboardEvent, kifuId: string) {
+    if (mode !== 'with-actions') return;
+
+    // ポップアップメニュー内のクリックはカード自体のクリックイベントを発火させない
+    if ((event.target as HTMLElement).closest('.popup-menu')) {
+      return;
+    }
+    selectedKifuId = selectedKifuId === kifuId ? null : kifuId;
+  }
+
+  // アクションハンドラ
+  function handleTogglePublic(kifu: KifuSummary) {
+    togglePublic(kifu);
+    selectedKifuId = null;
+  }
+
+  function handleDelete(kifuId: string) {
+    deleteKifu(kifuId);
+    selectedKifuId = null;
+  }
+</script>
+
+{#if loading}
+  <div class="loading">読み込み中...</div>
+{:else if kifuList.length === 0}
+  <div class="loading">棋譜はありません。</div>
+{:else}
+  <div class="kifu-list-container">
+    {#each kifuList as kifu}
+      {#if mode === 'with-actions'}
+        <!-- アクション付きカード（ホームページ用） -->
+        <div class="kifu-list-item">
+          <button
+            type="button"
+            class="card kifu-card"
+            class:selected={selectedKifuId === kifu.id}
+            on:click={(e) => handleCardClick(e, kifu.id)}
+            on:keydown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleCardClick(e, kifu.id);
+              }
+            }}
+            aria-expanded={selectedKifuId === kifu.id}
+            aria-haspopup="menu"
+            aria-controls={`menu-${kifu.id}`}
+          >
+            <div class="kifu-header">
+              <h3>{kifu.title}</h3>
+              <span class={`kifu-status ${kifu.is_public ? 'public' : 'private'}`}>
+                {kifu.is_public ? '公開' : '非公開'}
+              </span>
+            </div>
+            <div class="kifu-info">
+              <span>対局日: {kifu.game_info.date}</span>
+              <span>先手: {kifu.game_info.black}</span>
+              <span>後手: {kifu.game_info.white}</span>
+            </div>
+            <div class="kifu-tags">
+              {#each kifu.tags as tag}
+                <span class="tag">{tag}</span>
+              {/each}
+            </div>
+          </button>
+
+          {#if selectedKifuId === kifu.id}
+            <div id={`menu-${kifu.id}`} class="popup-menu" role="menu">
+              <a href={`/kifu/view?id=${kifu.id}`} class="menu-item" role="menuitem">
+                詳細を見る
+              </a>
+              <a href={`/kifu/edit?id=${kifu.id}`} class="menu-item" role="menuitem"> 編集する </a>
+              <button
+                type="button"
+                class="menu-item"
+                role="menuitem"
+                on:click={() => handleTogglePublic(kifu)}
+              >
+                {kifu.is_public ? '非公開にする' : '公開する'}
+              </button>
+              <button
+                type="button"
+                class="menu-item delete"
+                role="menuitem"
+                on:click={() => handleDelete(kifu.id)}
+              >
+                削除する
+              </button>
+            </div>
+          {/if}
+        </div>
+      {:else}
+        <!-- 閲覧専用カード（検索・アカウントページ用） -->
+        <a href={`/kifu/view?id=${kifu.id}`} class="card kifu-card">
+          <div class="kifu-header">
+            <h3>{kifu.title}</h3>
+          </div>
+          <div class="kifu-info">
+            <span>対局日: {kifu.game_info.date}</span>
+            <span>対局者: {kifu.game_info.black} vs {kifu.game_info.white}</span>
+          </div>
+          <div class="kifu-tags">
+            {#each kifu.tags as tag}
+              <span class="tag">{tag}</span>
+            {/each}
+          </div>
+        </a>
+      {/if}
+    {/each}
+  </div>
+
+  <!-- ページネーション -->
+  {#if pagination}
+    <div class="pagination">
+      <button
+        class="page-button"
+        disabled={pagination.page === 1}
+        on:click={() => handleChangePage(pagination.page - 1)}
+      >
+        前へ
+      </button>
+
+      {#each Array(pagination.max_page) as _, i}
+        <button
+          class="page-button"
+          class:active={pagination.page === i + 1}
+          on:click={() => handleChangePage(i + 1)}
+        >
+          {i + 1}
+        </button>
+      {/each}
+
+      <button
+        class="page-button"
+        disabled={pagination.page === pagination.max_page}
+        on:click={() => handleChangePage(pagination.page + 1)}
+      >
+        次へ
+      </button>
+    </div>
+  {/if}
+{/if}
+
+<style lang="scss">
+  .loading {
+    text-align: center;
+    padding: 2rem;
+    color: #666;
+  }
+
+  .kifu-list-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    .kifu-list-item {
+      position: relative;
+    }
+
+    .kifu-card {
+      display: block;
+      width: 100%;
+      padding: 1rem 1.5rem;
+      transition:
+        transform 0.2s,
+        box-shadow 0.2s;
+
+      .kifu-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+
+        .kifu-status {
+          font-size: 0.8rem;
+          padding: 0.25rem 0.5rem;
+          border-radius: 0.2rem;
+
+          &.public {
+            background-color: var(--public-icon-background-color);
+            color: var(--public-icon-text-color);
+          }
+
+          &.private {
+            background-color: var(--private-icon-background-color);
+            color: var(--private-icon-text-color);
+          }
+        }
+      }
+
+      .kifu-info {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin-bottom: 0.3rem;
+        font-size: 0.9rem;
+        color: #666;
+      }
+
+      .kifu-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        justify-content: end;
+
+        .tag {
+          background-color: var(--secondary-color);
+          color: white;
+          padding: 0.2rem 0.4rem;
+          border-radius: 0.2rem;
+          font-size: 0.8rem;
+        }
+      }
+    }
+
+    .popup-menu {
+      position: absolute;
+      top: -1rem;
+      right: 1rem;
+      background: var(--pickup-color);
+      border-radius: 0.4rem;
+      box-shadow: 0 0 0.8rem #696;
+      z-index: var(--z-index-popup);
+      min-width: 12rem;
+
+      .menu-item {
+        display: block;
+        padding: 0.4rem 0.8rem;
+        width: 100%;
+        text-align: left;
+        font-size: 1rem;
+
+        &:hover {
+          background-color: var(--pickup-strong-color);
+        }
+
+        &.delete {
+          color: #e53e3e;
+          border-top: 1px solid var(--border-color);
+        }
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/stores/session.ts
+++ b/frontend/src/lib/stores/session.ts
@@ -1,6 +1,6 @@
 // src/lib/stores/session.ts
 
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { browser } from '$app/environment';
 import type { Account } from '$lib/types/Account';
 import { refreshSession } from '$lib/apis/session';

--- a/frontend/src/lib/types/API.ts
+++ b/frontend/src/lib/types/API.ts
@@ -3,17 +3,51 @@
 import { sessionToken } from '$lib/stores/session';
 import { get } from 'svelte/store';
 
+export interface PaginationResponse {
+  total_count: number;
+  page: number;
+  page_size: number;
+  max_page: number;
+}
+
 export interface ApiResult {
   ok: boolean;
   data?: any;
+  pagination?: PaginationResponse;
 }
 
 export class API {
   static server = 'http://192.168.11.12:8080'; // 開発サーバー
 
-  static async get(path: string, params: any, withToken = true): Promise<ApiResult> {
-    const url = this.server + path;
+  private static async call(
+    method: string,
+    path: string,
+    queries?: any,
+    params?: any,
+    withToken = true
+  ): Promise<ApiResult> {
+    let queryString = '';
+    if (queries) {
+      const search = new URLSearchParams();
+      Object.entries(queries).forEach(([key, value]) => {
+        if (value != null && value != undefined) {
+          if (Array.isArray(value)) {
+            // 配列の場合は複数のパラメータとして追加
+            value.forEach((v) => search.append(key, v.toString()));
+          } else {
+            // それ以外は単一のパラメーターとして追加
+            search.append(key, value.toString());
+          }
+        }
+      });
+      queryString = search.toString();
+    }
+    const url = queryString ? this.server + path + '?' + queryString : this.server + path;
+
     const headers: any = {};
+    if (params) {
+      headers['Content-Type'] = 'application/json';
+    }
     if (withToken) {
       const currentToken = get(sessionToken);
       if (currentToken) {
@@ -22,11 +56,15 @@ export class API {
         return { ok: false, data: 'no token error' };
       }
     }
+
+    const body = params ? JSON.stringify(params) : undefined;
+
     const response = await fetch(url, {
-      method: 'GET',
+      method: method,
       // mode: 'same-origin', // 開発サーバーではoriginが異なる
       cache: 'no-cache',
       headers: headers,
+      body: body,
     });
     if (!response.ok) {
       return {
@@ -37,32 +75,19 @@ export class API {
     return await response.json();
   }
 
-  static async post(path: string, params: any, withToken = true): Promise<ApiResult> {
-    const url = this.server + path;
-    const headers: any = {
-      'Content-Type': 'application/json',
-    };
-    if (withToken) {
-      const currentToken = get(sessionToken);
-      if (currentToken) {
-        headers['Authorization'] = `Bearer ${currentToken}`;
-      } else {
-        return { ok: false, data: 'no token error' };
-      }
-    }
-    const response = await fetch(url, {
-      method: 'POST',
-      // mode: 'same-origin', // 開発サーバーではoriginが異なる
-      cache: 'no-cache',
-      headers: headers,
-      body: JSON.stringify(params),
-    });
-    if (!response.ok) {
-      return {
-        ok: false,
-        data: `${response.status}: ${response.statusText}`,
-      };
-    }
-    return await response.json();
+  static async get(path: string, queries?: any, withToken = true): Promise<ApiResult> {
+    return await this.call('GET', path, queries, undefined, withToken);
+  }
+
+  static async post(path: string, params?: any, withToken = true): Promise<ApiResult> {
+    return await this.call('POST', path, undefined, params, withToken);
+  }
+
+  static async put(path: string, params?: any, withToken = true): Promise<ApiResult> {
+    return await this.call('PUT', path, undefined, params, withToken);
+  }
+
+  static async delete(path: string, params?: any, withToken = true): Promise<ApiResult> {
+    return await this.call('DELETE', path, undefined, params, withToken);
   }
 }

--- a/frontend/src/lib/types/Kifu.ts
+++ b/frontend/src/lib/types/Kifu.ts
@@ -1,121 +1,40 @@
 // src/lib/types/Kifu.ts
 
-export interface Kifu {
+import type { Account } from './Account';
+import type { PieceType } from './KifuPiece';
+
+export interface KifuSummary {
   id: string;
-  ownerId: string;
+  owner: Account;
   title: string;
-  matchInfo: GameInfo;
+  is_public: boolean;
+  updated_at: Date;
+  game_info: { [key: string]: string };
   tags: string[];
-  isPublic: boolean;
-  initialPosition?: BoardPosition;
-  moves: Move[]; // メインラインの指し手リスト
-  createdAt?: string; // 棋譜の作成日時
-  updatedAt?: string; // 最終更新日時
 }
 
-export interface GameInfo {
-  black: string; // 先手の対局者名
-  white: string; // 後手の対局者名
-  date: string; // 対局日
-  title?: string; // 大会名や対局タイトル
-  place?: string; // 対局場所
-  timeLimit?: {
-    // 持ち時間
-    initial?: number; // 初期時間（分）
-    byoyomi?: number; // 秒読み（秒）
-    increment?: number; // 加算（秒）
-  };
+export interface KifuDetail {
+  id: string;
+  owner: Account;
+  title: string;
+  is_public: boolean;
+  initial_position?: string; // SFEN format
+  created_at: string;
+  updated_at: string;
+  game_info: { [key: string]: string };
+  tags: string[];
+  moves: KifuMove[];
 }
 
-export interface BoardPosition {
-  pieces: {
-    position: CellPosition;
-    piece: PieceType;
-    isBlack: boolean; // true: 先手の駒, false: 後手の駒
-  }[];
-  hands?: {
-    // 初期状態での持ち駒
-    black: { [K in PieceType]?: number };
-    white: { [K in PieceType]?: number };
-  };
+export interface KifuMove {
+  number: number;
+  piece: PieceType;
+  from_place: number; // Use PIECE_PLACE_IN_HAND for moves from hand
+  to_place: number;
+  promote?: boolean;
+  catch_piece?: PieceType;
+  direction_sign?: string;
+  variations?: KifuMove[][]; // Array of move lines
+  comment?: string;
+  time_spent_ms?: number;
 }
-
-export interface Move {
-  moveNumber: number; // 手数
-  piece: PieceType; // 駒の種類
-  from?: CellPosition; // 移動元（持ち駒の場合はundefined）
-  to: CellPosition; // 移動先
-  isPromoted?: boolean; // 成りの有無
-  isCapture?: boolean; // 駒を取ったかどうか
-  captured?: PieceType; // 取った駒の種類（取った場合のみ）
-  comment?: string; // この手に対するコメント
-  variations?: Move[]; // この手の代わりとなる指し手（分岐）のリスト
-}
-
-export interface CellPosition {
-  x: number; // 1-9の横位置
-  y: number; // 1-9の縦位置
-}
-
-export type PieceType =
-  | '歩'
-  | '香'
-  | '桂'
-  | '銀'
-  | '金'
-  | '角'
-  | '飛'
-  | 'と'
-  | '成香'
-  | '成桂'
-  | '成銀'
-  | '馬'
-  | '龍'
-  | '玉';
-
-// 使用例：
-/*
-const exampleKifu: Kifu = {
-  id: "kifu-1",
-  ownerId: "user-1",
-  title: "第1回天竜戦",
-  matchInfo: {
-    black: "先手太郎",
-    white: "後手次郎",
-    date: "2024-01-01",
-    title: "天竺戦",
-    timeLimit: {
-      initial: 120,
-      byoyomi: 30
-    }
-  },
-  tags: ["実戦", "居飛車"],
-  isPublic: true,
-  moves: [
-    {
-      moveNumber: 1,
-      piece: "歩",
-      from: { x: 7, y: 7 },
-      to: { x: 7, y: 6 },
-      variations: [
-        {
-          moveNumber: 1,
-          piece: "歩",
-          from: { x: 5, y: 7 },
-          to: { x: 5, y: 6 },
-          comment: "５六歩と指す作戦もある"
-        }
-      ]
-    },
-    {
-      moveNumber: 2,
-      piece: "歩",
-      from: { x: 3, y: 3 },
-      to: { x: 3, y: 4 }
-    }
-    // ... 以降の指し手
-  ],
-  createdAt: "2024-01-01 12:00",
-  updatedAt: "2024-01-01 15:30"
-};
-*/

--- a/frontend/src/lib/types/KifuPiece.ts
+++ b/frontend/src/lib/types/KifuPiece.ts
@@ -1,0 +1,22 @@
+// src/lib/types/Piece.ts
+
+export const enum PieceType {
+  PROMOTE = 0x8,
+  FU = 0x0,
+  KY = 0x1,
+  KE = 0x2,
+  GI = 0x3,
+  KI = 0x4,
+  KA = 0x5,
+  HI = 0x6,
+  OU = 0x7,
+  TO = 0x8, // FU | PROMOTE
+  NY = 0x9, // KY | PROMOTE
+  NK = 0xa, // KE | PROMOTE
+  NG = 0xb, // GI | PROMOTE
+  UM = 0xd, // KA | PROMOTE
+  RY = 0xe, // HI | PROMOTE
+  VACANCY = 0xf,
+}
+
+export const PIECE_PLACE_IN_HAND = 0xff;

--- a/frontend/src/routes/home/+page.svelte
+++ b/frontend/src/routes/home/+page.svelte
@@ -2,9 +2,14 @@
 
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { Kifu } from '$lib/types/Kifu';
+  import type { KifuSummary } from '$lib/types/Kifu';
+  import KifuList from '$lib/components/KifuList.svelte';
+  import { deleteKifu, searchKifus, updateKifuInfo } from '$lib/apis/kifu';
+  import type { PaginationResponse } from '$lib/types/API';
+  import { account } from '$lib/stores/session';
 
-  // モック通知データ
+  // ----------------------------------------
+  // 通知リスト
   interface Notification {
     id: string;
     type: 'like' | 'comment';
@@ -19,113 +24,100 @@
   let notifications: Notification[] = [];
   let unreadCount = 0;
 
-  // モック棋譜データ
-  let kifuList: Kifu[] = [];
-  let isLoading = false;
+  async function fetchNotificationList() {
+    notifications = [
+      {
+        id: '1',
+        type: 'like',
+        kifuId: 'kifu-1',
+        kifuTitle: '第1局：四間飛車',
+        userId: 'user-2',
+        userName: '許褚クリスティーナ',
+        createdAt: '2024-01-10 15:30',
+        read: false,
+      },
+      {
+        id: '2',
+        type: 'comment',
+        kifuId: 'kifu-2',
+        kifuTitle: '第2局：矢倉',
+        userId: 'user-3',
+        userName: '程昱ティノラベッラ',
+        createdAt: '2024-01-09 18:45',
+        read: true,
+      },
+    ];
 
-  // 選択中の棋譜ID（ポップアップ用）
-  let selectedKifuId: string | null = null;
-
-  // ページネーションの状態管理
-  let currentPage = 1;
-  const itemsPerPage = 10;
-  let totalPages = 1;
-
-  // モックデータを取得
-  async function fetchData() {
-    isLoading = true;
-    try {
-      // 通知データ
-      notifications = [
-        {
-          id: '1',
-          type: 'like',
-          kifuId: 'kifu-1',
-          kifuTitle: '第1局：四間飛車',
-          userId: 'user-2',
-          userName: '許褚クリスティーナ',
-          createdAt: '2024-01-10 15:30',
-          read: false,
-        },
-        {
-          id: '2',
-          type: 'comment',
-          kifuId: 'kifu-2',
-          kifuTitle: '第2局：矢倉',
-          userId: 'user-3',
-          userName: '程昱ティノラベッラ',
-          createdAt: '2024-01-09 18:45',
-          read: true,
-        },
-      ];
-
-      unreadCount = notifications.filter((n) => !n.read).length;
-
-      // 棋譜リスト
-      kifuList = Array(15)
-        .fill(null)
-        .map((_, i) => ({
-          id: `kifu-${i + 1}`,
-          ownerId: 'current-user',
-          title: `第${i + 1}局：${['四間飛車', '矢倉', '角換わり', '横歩取り', '相掛かり'][i % 5]}`,
-          matchInfo: {
-            black: '曹操オッキマラ',
-            white: ['許褚クリスティーナ', '程昱ティノラベッラ', '夏侯惇', '夏侯淵', '張遼'][i % 5],
-            date: '2024-01-01',
-          },
-          tags: ['実戦', ['四間飛車', '矢倉', '角換わり', '横歩取り', '相掛かり'][i % 5]],
-          isPublic: i % 2 === 0,
-          moves: [],
-        }));
-
-      totalPages = Math.ceil(kifuList.length / itemsPerPage);
-    } finally {
-      isLoading = false;
-    }
+    unreadCount = notifications.filter((n) => !n.read).length;
   }
 
-  // ページネーションで表示する棋譜リスト
-  $: paginatedKifuList = kifuList.slice(
-    (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage
-  );
-
-  // ページ変更
-  function changePage(page: number) {
-    if (page >= 1 && page <= totalPages) {
-      currentPage = page;
-      selectedKifuId = null; // ページ変更時にポップアップを閉じる
-    }
-  }
-
-  // 通知を既読にする
   function markAsRead(notificationId: string) {
     notifications = notifications.map((n) => (n.id === notificationId ? { ...n, read: true } : n));
     unreadCount = notifications.filter((n) => !n.read).length;
   }
 
-  // 棋譜の公開状態を切り替え
-  function togglePublic(kifuId: string) {
-    kifuList = kifuList.map((k) => (k.id === kifuId ? { ...k, isPublic: !k.isPublic } : k));
-    selectedKifuId = null;
-  }
+  // ----------------------------------------
+  // 棋譜リスト
+  let isLoadingKifuList = true;
+  let kifuList: KifuSummary[] = [];
+  let pagination: PaginationResponse = {
+    total_count: 0,
+    page: 1,
+    page_size: 10,
+    max_page: 1,
+  };
 
-  // 棋譜を削除
-  function deleteKifu(kifuId: string) {
-    kifuList = kifuList.filter((k) => k.id !== kifuId);
-    selectedKifuId = null;
-  }
+  async function fetchKifuList() {
+    isLoadingKifuList = true;
 
-  // イベントハンドラ（MouseEventとKeyboardEventの両方に対応）
-  function handleCardClick(event: MouseEvent | KeyboardEvent, kifuId: string) {
-    // ポップアップメニュー内のクリックはカード自体のクリックイベントを発火させない
-    if ((event.target as HTMLElement).closest('.popup-menu')) {
-      return;
+    const result = await searchKifus('me', pagination.page, pagination.page_size, true);
+    if (result.ok && result.data && result.pagination) {
+      kifuList = result.data as KifuSummary[];
+      pagination = result.pagination;
+    } else {
+      kifuList = []; // エラー時はリストをクリア
+      console.error('Failed to fetch kifu list: ', result);
     }
-    selectedKifuId = selectedKifuId === kifuId ? null : kifuId;
+
+    isLoadingKifuList = false;
   }
 
-  onMount(fetchData);
+  async function handleChangePage(page: number) {
+    pagination.page = page;
+    await fetchKifuList();
+  }
+
+  async function handleTogglePublic(kifu: KifuSummary) {
+    const result = await updateKifuInfo(
+      kifu.id,
+      kifu.title,
+      !kifu.is_public,
+      kifu.game_info,
+      kifu.tags
+    );
+    if (result.ok) {
+      await fetchKifuList();
+    } else {
+      console.error('Failed to toggle public: ', result);
+    }
+  }
+
+  async function handleDeleteKifu(kifuId: string) {
+    const result = await deleteKifu(kifuId);
+    if (result.ok) {
+      await fetchKifuList();
+    } else {
+      console.error('Failed to delete kifu: ', result);
+    }
+  }
+
+  // ----------------------------------------
+  // 初回データロード
+
+  $: if (account) {
+    fetchNotificationList();
+    fetchKifuList();
+  }
 </script>
 
 <div class="page">
@@ -168,108 +160,15 @@
   <!-- 棋譜リストセクション -->
   <section class="basic kifu-list">
     <h2>自分の棋譜</h2>
-    {#if isLoading}
-      <div class="loading">読み込み中...</div>
-    {:else if currentPage == 1 && paginatedKifuList.length === 0}
-      <div class="loading">棋譜はまだありません。</div>
-    {:else}
-      <div class="kifu-list-container">
-        {#each paginatedKifuList as kifu}
-          <div class="kifu-list-item">
-            <button
-              type="button"
-              class="card kifu-card"
-              class:selected={selectedKifuId === kifu.id}
-              on:click={(e) => handleCardClick(e, kifu.id)}
-              on:keydown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleCardClick(e, kifu.id);
-                }
-              }}
-              aria-expanded={selectedKifuId === kifu.id}
-              aria-haspopup="menu"
-              aria-controls={`menu-${kifu.id}`}
-            >
-              <div class="kifu-header">
-                <h3>{kifu.title}</h3>
-                <span class={`kifu-status ${kifu.isPublic ? 'public' : 'private'}`}>
-                  {kifu.isPublic ? '公開' : '非公開'}
-                </span>
-              </div>
-
-              <div class="kifu-info">
-                <span>対局日: {kifu.matchInfo.date}</span>
-                <span>先手: {kifu.matchInfo.black}</span>
-                <span>後手: {kifu.matchInfo.white}</span>
-              </div>
-
-              <div class="kifu-tags">
-                {#each kifu.tags as tag}
-                  <span class="tag">{tag}</span>
-                {/each}
-              </div>
-            </button>
-
-            {#if selectedKifuId === kifu.id}
-              <div id={`menu-${kifu.id}`} class="popup-menu" role="menu">
-                <a href={`/kifu/view?id=${kifu.id}`} class="menu-item" role="menuitem">
-                  詳細を見る
-                </a>
-                <a href={`/kifu/edit?id=${kifu.id}`} class="menu-item" role="menuitem">
-                  編集する
-                </a>
-                <button
-                  type="button"
-                  class="menu-item"
-                  role="menuitem"
-                  on:click={() => togglePublic(kifu.id)}
-                >
-                  {kifu.isPublic ? '非公開にする' : '公開する'}
-                </button>
-                <button
-                  type="button"
-                  class="menu-item delete"
-                  role="menuitem"
-                  on:click={() => deleteKifu(kifu.id)}
-                >
-                  削除する
-                </button>
-              </div>
-            {/if}
-          </div>
-        {/each}
-      </div>
-
-      <!-- ページネーション -->
-      <div class="pagination">
-        <button
-          class="page-button"
-          disabled={currentPage === 1}
-          on:click={() => changePage(currentPage - 1)}
-        >
-          前へ
-        </button>
-
-        {#each Array(totalPages) as _, i}
-          <button
-            class="page-button"
-            class:active={currentPage === i + 1}
-            on:click={() => changePage(i + 1)}
-          >
-            {i + 1}
-          </button>
-        {/each}
-
-        <button
-          class="page-button"
-          disabled={currentPage === totalPages}
-          on:click={() => changePage(currentPage + 1)}
-        >
-          次へ
-        </button>
-      </div>
-    {/if}
+    <KifuList
+      {kifuList}
+      {pagination}
+      loading={isLoadingKifuList}
+      mode="with-actions"
+      changePage={handleChangePage}
+      togglePublic={handleTogglePublic}
+      deleteKifu={handleDeleteKifu}
+    />
   </section>
 </div>
 
@@ -346,107 +245,6 @@
           &:hover {
             background-color: var(--primary-color);
             color: white;
-          }
-        }
-      }
-    }
-  }
-
-  section.kifu-list {
-    .loading {
-      text-align: center;
-      padding: 2rem;
-      color: #666;
-    }
-
-    .kifu-list-container {
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-
-      .kifu-list-item {
-        position: relative;
-
-        .kifu-card {
-          display: block;
-          width: 100%;
-          padding: 1rem 1.5rem;
-          transition:
-            transform 0.2s,
-            box-shadow 0.2s;
-
-          .kifu-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-
-            .kifu-status {
-              font-size: 0.8rem;
-              padding: 0.25rem 0.5rem;
-              border-radius: 0.2rem;
-
-              &.public {
-                background-color: var(--public-icon-background-color);
-                color: var(--public-icon-text-color);
-              }
-
-              &.private {
-                background-color: var(--private-icon-background-color);
-                color: var(--private-icon-text-color);
-              }
-            }
-          }
-
-          .kifu-info {
-            display: flex;
-            align-items: center;
-            gap: 1rem;
-            margin-bottom: 0.3rem;
-            font-size: 0.9rem;
-            color: #666;
-          }
-
-          .kifu-tags {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-            justify-content: end;
-
-            .tag {
-              background-color: var(--secondary-color);
-              color: white;
-              padding: 0.2rem 0.4rem;
-              border-radius: 0.2rem;
-              font-size: 0.8rem;
-            }
-          }
-        }
-
-        .popup-menu {
-          position: absolute;
-          top: -1rem;
-          right: 1rem;
-          background: var(--pickup-color);
-          border-radius: 0.4rem;
-          box-shadow: 0 0 0.8rem #696;
-          z-index: var(--z-index-popup);
-          min-width: 12rem;
-
-          .menu-item {
-            display: block;
-            padding: 0.4rem 0.8rem;
-            width: 100%;
-            text-align: left;
-            font-size: 1rem;
-
-            &:hover {
-              background-color: var(--pickup-strong-color);
-            }
-
-            &.delete {
-              color: #e53e3e;
-              border-top: 1px solid var(--border-color);
-            }
           }
         }
       }


### PR DESCRIPTION
フロントエンド側で棋譜リストの取得と表示をできるようにしました。
対象ページは、ホーム、棋譜検索、アカウント情報の３つのページです。

- 棋譜の型の定義をサーバー側の変更に合わせて修正
- ３つのページに存在した棋譜一覧をコンポーネントとして分離
- 棋譜関係のAPIクライアントを実装
- ３つのページでAPIをコールして正しい棋譜一覧を表示するように実装