### PR TITLE
account info page

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -42,6 +42,8 @@ func main() {
 		ra.GET("/test", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"result": "OK"}) })
 		ra.POST("/account", handler.HandlerIn(api.CreateAccount))
 		ra.POST("/session/login", handler.HandlerInOut(api.Login))
+
+		ra.GET("/account/:accountID", handler.HandlerOut(api.GetAccountByID))
 	}
 
 	// public endpoints (optional authentication)
@@ -53,7 +55,7 @@ func main() {
 	}
 
 	// require session
-	rs := rp.Group("/")
+	rs := ra.Group("/")
 	rs.Use(handler.MwRequireSession)
 	{
 		rs.GET("/account", handler.HandlerOut(api.GetAccount))

--- a/api/service/api/account.go
+++ b/api/service/api/account.go
@@ -45,6 +45,15 @@ func GetAccount(c *gin.Context) (*model.AccountResponse, string, error) {
 	return account.ToResponse(), "", nil
 }
 
+func GetAccountByID(c *gin.Context) (*model.AccountResponse, string, error) {
+	aid := c.GetString("accountID")
+	account, err := dao.GetAccountByID(aid)
+	if err != nil {
+		return nil, "Failed to get account", err
+	}
+	return account.ToResponse(), "", nil
+}
+
 func DeleteAccount(c *gin.Context) (string, error) {
 	aid := handler.GetAccountID(c)
 

--- a/api/swagger/api.yml
+++ b/api/swagger/api.yml
@@ -27,7 +27,7 @@ paths:
         '500':
           $ref: '#/components/responses/ErrorResponse'
     get:
-      summary: アカウント情報の取得
+      summary: アカウント情報の取得（自身）
       tags: [Account]
       security:
         - BearerAuth: []
@@ -69,6 +69,23 @@ paths:
           $ref: '#/components/responses/ErrorResponse'
         '401':
           $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+  /api/account/{accountID}:
+    parameters:
+      - name: accountID
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: アカウント情報の取得（ID指定）
+      tags: [Account]
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          $ref: '#/components/responses/AccountResponse'
         '500':
           $ref: '#/components/responses/ErrorResponse'
   /api/session/login:

--- a/frontend/src/lib/apis/account.ts
+++ b/frontend/src/lib/apis/account.ts
@@ -30,3 +30,13 @@ export const getAccount = async (): Promise<ApiResult> => {
   }
   return result;
 };
+
+export const getAccountById = async (accountId: string): Promise<ApiResult> => {
+  const result = await API.get(`/api/account/${accountId}`, null, false);
+  if (!result.data) {
+    console.error('get account error: no data');
+    result.ok = false;
+    result.data = 'アカウント情報の取得に失敗しました。';
+  }
+  return result;
+};

--- a/frontend/src/routes/account/+page.svelte
+++ b/frontend/src/routes/account/+page.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import { page } from '$app/stores';
+  import { getAccountById } from '$lib/apis/account';
   import { searchKifus } from '$lib/apis/kifu';
   import KifuList from '$lib/components/KifuList.svelte';
   import { account } from '$lib/stores/session';
@@ -19,16 +20,15 @@
 
   const fetchAccountData = async () => {
     isLoadingAccount = true;
-    await new Promise((resolve) => setTimeout(resolve, 500)); // ローディング表示確認用
 
-    // TODO: MOCに代えてAPIからデータを取得
-    accountInfo = {
-      id: accountId || '',
-      name: 'サンプルユーザー',
-      introduction: '自己紹介～～～～～～～～～～～～～～',
-      created_at: new Date(),
-      last_login_at: new Date(),
-    };
+    if (accountId) {
+      const result = await getAccountById(accountId);
+      if (result.ok && result.data) {
+        accountInfo = result.data as Account;
+      } else {
+        console.error('Failed to fetch account data:', result);
+      }
+    }
 
     isLoadingAccount = false;
   };
@@ -98,6 +98,10 @@
           </div>
         </div>
       </div>
+    {:else}
+      <div class="error">
+        <p>アカウント情報の取得に失敗しました。</p>
+      </div>
     {/if}
   </section>
 
@@ -144,82 +148,6 @@
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
-      }
-    }
-  }
-
-  .kifu-list-container {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-
-    .kifu-card {
-      display: block;
-      width: 100%;
-      padding: 1rem 1.5rem;
-      transition:
-        transform 0.2s,
-        box-shadow 0.2s;
-
-      .kifu-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-      }
-
-      .kifu-info {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        margin-bottom: 0.3rem;
-        font-size: 0.9rem;
-        color: #666;
-      }
-
-      .kifu-tags {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        justify-content: end;
-
-        .tag {
-          background-color: var(--secondary-color);
-          color: white;
-          padding: 0.2rem 0.4rem;
-          border-radius: 0.2rem;
-          font-size: 0.8rem;
-        }
-      }
-    }
-  }
-
-  .pagination {
-    display: flex;
-    justify-content: center;
-    gap: 0.5rem;
-    margin-top: 2rem;
-
-    .page-button {
-      padding: 0.5rem 1rem;
-      border: 1px solid var(--border-color);
-      border-radius: 4px;
-      background: white;
-
-      &:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-      }
-
-      &.active {
-        background-color: var(--primary-color);
-        color: white;
-        border-color: var(--primary-color);
-      }
-
-      &:not(:disabled):hover {
-        background-color: var(--secondary-color);
-        color: white;
-        border-color: var(--secondary-color);
       }
     }
   }


### PR DESCRIPTION
アカウント詳細ページにアカウント情報が表示されるようにしました。

- API側で GET /account/{accountID} を実装
- swaggerのAPI定義を追加
- frontend側でアカウント詳細ページにデータ取得を実装
