### PR TITLE
指し手の編集のベースを作成

### DIFF
--- a/frontend/src/lib/components/MovesEditor.svelte
+++ b/frontend/src/lib/components/MovesEditor.svelte
@@ -1,17 +1,41 @@
 <!-- src/lib/components/MovesEditor.svelte -->
 
 <script lang="ts">
+  import { BoardPosition } from '$lib/types/BoardPosition';
   import type { KifuMove } from '$lib/types/Kifu';
+  import { PieceType } from '$lib/types/Piece';
   import BoardPositionView from './PositionView/PositionView.svelte';
 
   // callback
   export let onChange: (moves: KifuMove[]) => void;
 
   // parameters
-  export let initial: string | undefined;
+  export let initialSfen: string | undefined;
   export let moveList: KifuMove[];
+  $: moveNumber = moveList.length;
+  $: currentSfen = generateMovedSfen(initialSfen, moveList, moveNumber);
+  $: isBlackFirst = isBlackOfSfen(initialSfen);
 
-  let moveNumber = 0;
+  const generateMovedSfen = (
+    sfen: string | undefined,
+    moves: KifuMove[],
+    num: number
+  ): string | undefined => {
+    const position = new BoardPosition(sfen);
+    for (let i = 0; i < num; i++) {
+      if (i >= moves.length) {
+        console.error('move number is over moves count');
+      }
+      position.next(moves[i]);
+    }
+    return position.toSfen(1); // 手数は1固定
+  };
+
+  const isBlackOfSfen = (sfen?: string) => {
+    if (!sfen) return true;
+    const parts = sfen.split(' ');
+    return parts[1] === 'b';
+  };
 
   let handleToStart = () => {
     moveNumber = 0;
@@ -26,14 +50,37 @@
     moveNumber = moveList.length;
   };
 
-  const handleChange = (position?: string, moves?: KifuMove[]) => {
-    if (!moves) return;
-    onChange(moves);
+  $: if (moveList) {
+    console.debug('MovesEditor moveList:', moveList);
+  }
+
+  const handleAppendMove = (num: number, move: KifuMove) => {
+    const newMoveList = moveList.slice(0, num - 1);
+    newMoveList.push(move);
+    moveNumber++;
+    onChange(newMoveList);
+  };
+  const handlePromote = (promote: boolean) => {
+    if (!moveList.length) {
+      return;
+    }
+    moveList[moveList.length - 1].promote = promote;
+    if (promote) {
+      moveList[moveList.length - 1].piece = moveList[moveList.length - 1].piece | PieceType.PROMOTE;
+    }
   };
 </script>
 
 <div class="position-editor">
-  <BoardPositionView mode="moves" sfen={initial} {moveList} {moveNumber} onChange={handleChange} />
+  <BoardPositionView
+    mode="moves"
+    {isBlackFirst}
+    sfen={currentSfen}
+    {moveList}
+    {moveNumber}
+    onAppendMove={handleAppendMove}
+    onPromote={handlePromote}
+  />
   <div class="controls">
     <button onclick={handleToStart}>|◀</button>
     <button onclick={handleToPrev}>◀</button>

--- a/frontend/src/lib/components/MovesEditor.svelte
+++ b/frontend/src/lib/components/MovesEditor.svelte
@@ -1,0 +1,64 @@
+<!-- src/lib/components/MovesEditor.svelte -->
+
+<script lang="ts">
+  import type { KifuMove } from '$lib/types/Kifu';
+  import BoardPositionView from './PositionView/PositionView.svelte';
+
+  // callback
+  export let onChange: (moves: KifuMove[]) => void;
+
+  // parameters
+  export let initial: string | undefined;
+  export let moveList: KifuMove[];
+
+  let moveNumber = 0;
+
+  let handleToStart = () => {
+    moveNumber = 0;
+  };
+  let handleToPrev = () => {
+    if (moveNumber > 0) moveNumber--;
+  };
+  let handleToNext = () => {
+    if (moveNumber < moveList.length) moveNumber++;
+  };
+  let handleToEnd = () => {
+    moveNumber = moveList.length;
+  };
+
+  const handleChange = (position?: string, moves?: KifuMove[]) => {
+    if (!moves) return;
+    onChange(moves);
+  };
+</script>
+
+<div class="position-editor">
+  <BoardPositionView mode="moves" sfen={initial} {moveList} {moveNumber} onChange={handleChange} />
+  <div class="controls">
+    <button onclick={handleToStart}>|◀</button>
+    <button onclick={handleToPrev}>◀</button>
+    <button onclick={handleToNext}>▶</button>
+    <button onclick={handleToEnd}>▶|</button>
+  </div>
+</div>
+
+<style>
+  .controls {
+    margin-top: 0.5rem;
+    text-align: center;
+
+    button {
+      width: 6rem;
+      padding: 0.3rem 0.5rem;
+      background-color: var(--primary-color);
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+
+      &:hover {
+        opacity: 0.9;
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/components/PositionEditor.svelte
+++ b/frontend/src/lib/components/PositionEditor.svelte
@@ -1,37 +1,141 @@
 <!-- src/lib/components/PositionEditor.svelte -->
 
 <script lang="ts">
-  import type { KifuMove } from '$lib/types/Kifu';
+  import { BoardPosition } from '$lib/types/BoardPosition';
+  import { PieceType, type PieceClickEvent } from '$lib/types/Piece';
   import BoardPositionView from './PositionView/PositionView.svelte';
 
   // callback
-  export let onChange: (position?: string) => void;
+  export let onChange: (newSfen?: string) => void;
 
-  let boardPosition: string | undefined;
+  let sfen: string | undefined = undefined;
 
-  const handleChange = (position?: string, moves?: KifuMove[]) => {
-    boardPosition = position;
-    onChange(position);
+  const handleToggleTurn = () => {
+    const position = new BoardPosition(sfen);
+    position.isBlackTurn = !position.isBlackTurn;
+    sfen = position.toSfen(1); // 手数は1固定
+    onChange(sfen);
   };
 
-  const reset = () => {
-    // TEST POSITION
-    // boardPosition = 'lnsg5/9/ppppp4/9/9/9/PPPPPPP2/9/4KGSNL b 2PLNSGBR2plnsgbr 1';
-    boardPosition = undefined;
-    onChange(boardPosition);
+  const handleRotatePiece = (row: number, col: number, isBlack: boolean) => {
+    const position = new BoardPosition(sfen);
+
+    // 先手の表駒 -> 先手の成駒 -> 後手の表駒 -> 後手の成駒
+    if (isBlack) {
+      const piece = position.blackBoard[row][col];
+      if (piece & PieceType.PROMOTE || piece === PieceType.KI || piece === PieceType.OU) {
+        // 先手の成駒or金or王 -> 後手の表駒
+        position.whiteBoard[row][col] = piece & ~PieceType.PROMOTE;
+        position.blackBoard[row][col] = PieceType.VACANCY;
+      } else {
+        // 先手の表駒 -> 先手の成駒
+        position.blackBoard[row][col] = piece | PieceType.PROMOTE;
+      }
+    } else {
+      const piece = position.whiteBoard[row][col];
+      if (piece & PieceType.PROMOTE || piece === PieceType.KI || piece === PieceType.OU) {
+        // 後手の成駒or金or王 -> 先手の表駒
+        position.blackBoard[row][col] = piece & ~PieceType.PROMOTE;
+        position.whiteBoard[row][col] = PieceType.VACANCY;
+      } else {
+        // 後手の表駒 -> 後手の成駒
+        position.whiteBoard[row][col] = piece | PieceType.PROMOTE;
+      }
+    }
+
+    sfen = position.toSfen(1); // 手数は1固定
+    onChange(sfen);
   };
 
-  const allRemove = () => {
-    boardPosition = '9/9/9/9/9/9/9/9/9 b - 1';
-    onChange(boardPosition);
+  const handleMovePiece = (moving: PieceClickEvent, target: PieceClickEvent) => {
+    const position = new BoardPosition(sfen);
+
+    // 移動先に駒がある場合、持ち駒へ
+    if (target.source.type === 'board') {
+      if (target.pieceType !== PieceType.VACANCY) {
+        const originalType = target.pieceType & ~PieceType.PROMOTE;
+        if (originalType === PieceType.OU) {
+          // targetが玉の場合は、targetは駒箱へ
+          const num = position.pieceBox.get(originalType) ?? 0;
+          position.pieceBox.set(originalType, num + 1);
+        } else if (moving.source.type === 'box' || moving.source.isBlack) {
+          // 移動中の駒が、駒箱からor先手の場合、targetは先手の持ち駒へ
+          const num = position.blackHands.get(originalType) ?? 0;
+          position.blackHands.set(originalType, num + 1);
+        } else {
+          // 移動中の駒が後手の場合、targetは後手の持ち駒へ
+          const num = position.whiteHands.get(originalType) ?? 0;
+          position.whiteHands.set(originalType, num + 1);
+        }
+      }
+    }
+
+    // 移動先に駒を配置
+    if (target.source.type === 'board') {
+      if (moving.source.type === 'box' || moving.source.isBlack) {
+        position.blackBoard[target.source.row][target.source.col] = moving.pieceType;
+        position.whiteBoard[target.source.row][target.source.col] = PieceType.VACANCY;
+      } else {
+        position.blackBoard[target.source.row][target.source.col] = PieceType.VACANCY;
+        position.whiteBoard[target.source.row][target.source.col] = moving.pieceType;
+      }
+    } else if (target.source.type === 'stand' || target.source.type === 'box') {
+      const targetContainer =
+        target.source.type === 'stand'
+          ? target.source.isBlack
+            ? position.blackHands
+            : position.whiteHands
+          : position.pieceBox;
+      const originalType = moving.pieceType & ~PieceType.PROMOTE;
+      const num = targetContainer.get(originalType) ?? 0;
+      targetContainer.set(originalType, num + 1);
+    }
+
+    // 移動元の駒を削除
+    if (moving.source.type === 'board') {
+      position.blackBoard[moving.source.row][moving.source.col] = PieceType.VACANCY;
+      position.whiteBoard[moving.source.row][moving.source.col] = PieceType.VACANCY;
+    } else if (moving.source.type === 'stand' || moving.source.type === 'box') {
+      const list =
+        moving.source.type === 'stand'
+          ? moving.source.isBlack
+            ? position.blackHands
+            : position.whiteHands
+          : position.pieceBox;
+      const num = list.get(moving.pieceType) || 0;
+      if (num > 1) {
+        list.set(moving.pieceType, num - 1);
+      } else {
+        list.delete(moving.pieceType);
+      }
+    }
+
+    sfen = position.toSfen(1); // 手数は1固定
+    onChange(sfen);
+  };
+
+  const handleReset = () => {
+    sfen = undefined;
+    onChange(sfen);
+  };
+
+  const handleAllInBox = () => {
+    sfen = '9/9/9/9/9/9/9/9/9 b - 1';
+    onChange(sfen);
   };
 </script>
 
 <div class="position-editor">
-  <BoardPositionView mode="position" sfen={boardPosition} onChange={handleChange} />
+  <BoardPositionView
+    mode="position"
+    {sfen}
+    onToggleTurn={handleToggleTurn}
+    onRotatePiece={handleRotatePiece}
+    onMovePiece={handleMovePiece}
+  />
   <div class="controls">
-    <button onclick={reset}>平手初形</button>
-    <button onclick={allRemove}>全て駒箱</button>
+    <button onclick={handleReset}>平手初形</button>
+    <button onclick={handleAllInBox}>全て駒箱</button>
   </div>
 </div>
 

--- a/frontend/src/lib/components/PositionEditor.svelte
+++ b/frontend/src/lib/components/PositionEditor.svelte
@@ -30,8 +30,8 @@
 <div class="position-editor">
   <BoardPositionView mode="position" sfen={boardPosition} onChange={handleChange} />
   <div class="controls">
-    <button on:click={reset}>平手初形</button>
-    <button on:click={allRemove}>全て駒箱</button>
+    <button onclick={reset}>平手初形</button>
+    <button onclick={allRemove}>全て駒箱</button>
   </div>
 </div>
 
@@ -42,7 +42,7 @@
 
     button {
       width: 10rem;
-      padding: 0.5rem 1rem;
+      padding: 0.3rem 0.5rem;
       background-color: var(--primary-color);
       color: white;
       border: none;

--- a/frontend/src/lib/components/PositionView/Board.svelte
+++ b/frontend/src/lib/components/PositionView/Board.svelte
@@ -2,7 +2,6 @@
 
 <script lang="ts">
   import { PieceType, type PieceClickEvent } from '$lib/types/Piece';
-  import { preventDefault } from 'svelte/legacy';
   import Piece from './Piece.svelte';
 
   export let blackBoard: PieceType[][];

--- a/frontend/src/lib/components/PositionView/MoveList.svelte
+++ b/frontend/src/lib/components/PositionView/MoveList.svelte
@@ -2,15 +2,9 @@
 
 <script lang="ts">
   import type { KifuMove } from '$lib/types/Kifu';
-  import {
-    fileChar,
-    fileNum,
-    PIECE_PLACE_IN_HAND,
-    PieceChar,
-    rankChar,
-    rankNum,
-  } from '$lib/types/Piece';
+  import { PiecePlace, PieceChar } from '$lib/types/Piece';
 
+  export let isBlackFirst: boolean = true; //ToDo: set in upper component
   export let moveList: KifuMove[];
   export let moveNumber: number;
   export let x: number;
@@ -18,26 +12,20 @@
   const w = 800;
   const h = 2400;
 
-  $: if (moveList) {
-    console.debug(moveList);
-  }
   const testMoveList: KifuMove[] = [
     { number: 1, piece: 0x0, from_place: 0x67, to_place: 0x57 },
     { number: 2, piece: 0x0, from_place: 0x21, to_place: 0x31 },
   ];
 
-  const formatMove = (move: KifuMove): string => {
+  const formatMove = (move: KifuMove, num: number): string => {
+    const turnMark = (isBlackFirst && num % 2 == 1) || (!isBlackFirst && num % 2 == 0) ? '▲' : '△';
+    const toPlace = new PiecePlace(move.to_place);
+    const toText = `${toPlace.fileChar()}${toPlace.rankChar()}`;
     const pieceChar = PieceChar.get(move.promote ? move.piece & ~0x8 : move.piece);
-    const toFileChar = fileChar(move.to_place);
-    const toRankChar = rankChar(move.to_place);
     const promoteText = move.promote ? '成' : move.promote === false ? '不成' : ''; // 3 variations: true, false, undefined
-    const fromText = ((place: number): string => {
-      if (place === PIECE_PLACE_IN_HAND) return '打';
-      const fromFile = fileNum(place);
-      const fromRank = rankNum(place);
-      return `(${fromFile}${fromRank})`;
-    })(move.from_place);
-    return `${toFileChar}${toRankChar}${pieceChar}${promoteText}${fromText}`;
+    const fromPlace = new PiecePlace(move.from_place);
+    const fromText = fromPlace.isInHand() ? '打' : `(${fromPlace.fileNum()}${fromPlace.rankNum()})`;
+    return `${turnMark}${toText}${pieceChar}${promoteText}${fromText}`;
   };
 </script>
 
@@ -48,10 +36,10 @@
       <span class="move-number">0</span>
       <span class="move-text">開始局面</span>
     </div>
-    {#each testMoveList as move, i}
+    {#each moveList as move, i}
       <div class="move-item" class:current={i + 1 === moveNumber}>
         <span class="move-number">{i + 1}</span>
-        <span class="move-text">{formatMove(move)}</span>
+        <span class="move-text">{formatMove(move, i + 1)}</span>
       </div>
     {/each}
   </div>
@@ -81,10 +69,6 @@
         width: 140px;
         text-align: right;
         color: #666;
-      }
-
-      .move-text {
-        font-weight: bold;
       }
     }
   }

--- a/frontend/src/lib/components/PositionView/MoveList.svelte
+++ b/frontend/src/lib/components/PositionView/MoveList.svelte
@@ -1,17 +1,91 @@
-<!-- src/lib/components/PieceStand.svelte -->
+<!-- src/lib/components/MoveList.svelte -->
 
 <script lang="ts">
   import type { KifuMove } from '$lib/types/Kifu';
+  import {
+    fileChar,
+    fileNum,
+    PIECE_PLACE_IN_HAND,
+    PieceChar,
+    rankChar,
+    rankNum,
+  } from '$lib/types/Piece';
 
   export let moveList: KifuMove[];
   export let moveNumber: number;
   export let x: number;
   export let y: number;
-  const w = 920;
+  const w = 800;
   const h = 2400;
+
+  $: if (moveList) {
+    console.debug(moveList);
+  }
+  const testMoveList: KifuMove[] = [
+    { number: 1, piece: 0x0, from_place: 0x67, to_place: 0x57 },
+    { number: 2, piece: 0x0, from_place: 0x21, to_place: 0x31 },
+  ];
+
+  const formatMove = (move: KifuMove): string => {
+    const pieceChar = PieceChar.get(move.promote ? move.piece & ~0x8 : move.piece);
+    const toFileChar = fileChar(move.to_place);
+    const toRankChar = rankChar(move.to_place);
+    const promoteText = move.promote ? '成' : move.promote === false ? '不成' : ''; // 3 variations: true, false, undefined
+    const fromText = ((place: number): string => {
+      if (place === PIECE_PLACE_IN_HAND) return '打';
+      const fromFile = fileNum(place);
+      const fromRank = rankNum(place);
+      return `(${fromFile}${fromRank})`;
+    })(move.from_place);
+    return `${toFileChar}${toRankChar}${pieceChar}${promoteText}${fromText}`;
+  };
 </script>
 
-<g transform={`translate(${x}, ${y})`}>
-  <rect width={w} height={h} fill="#666" />
-  <rect x="10" y="10" width={w - 20} height={h - 20} fill="#ffc" />
-</g>
+<foreignObject {x} {y} width={w} height={h}>
+  <!-- xmlns属性がTypeScriptの型チェックで警告の対象となるため回避 -->
+  <div {...{ xmlns: 'http://www.w3.org/1999/xhtml' } as any} class="moves-container">
+    <div class="move-item" class:current={0 === moveNumber}>
+      <span class="move-number">0</span>
+      <span class="move-text">開始局面</span>
+    </div>
+    {#each testMoveList as move, i}
+      <div class="move-item" class:current={i + 1 === moveNumber}>
+        <span class="move-number">{i + 1}</span>
+        <span class="move-text">{formatMove(move)}</span>
+      </div>
+    {/each}
+  </div>
+</foreignObject>
+
+<style>
+  .moves-container {
+    width: 100%;
+    height: 100%;
+    background: #fff;
+    border: 10px solid #ccc;
+    overflow-y: auto;
+
+    .move-item {
+      padding: 20px 40px;
+      display: flex;
+      gap: 40px;
+      align-items: baseline;
+      font-size: 80px;
+      line-height: 120px;
+
+      &.current {
+        background: #e0f0ff;
+      }
+
+      .move-number {
+        width: 140px;
+        text-align: right;
+        color: #666;
+      }
+
+      .move-text {
+        font-weight: bold;
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/components/PositionView/PositionView.svelte
+++ b/frontend/src/lib/components/PositionView/PositionView.svelte
@@ -4,7 +4,6 @@
   import { BoardPosition } from '$lib/types/BoardPosition';
   import type { KifuMove } from '$lib/types/Kifu';
   import { PieceType, type PieceClickEvent } from '$lib/types/Piece';
-  import PositionEditor from '../PositionEditor.svelte';
   import Board from './Board.svelte';
   import MoveList from './MoveList.svelte';
   import PieceBox from './PieceBox.svelte';

--- a/frontend/src/lib/components/PositionView/PositionView.svelte
+++ b/frontend/src/lib/components/PositionView/PositionView.svelte
@@ -1,9 +1,11 @@
 <!-- src/lib/components/PositionView/PositionView.svelte -->
 
+<!-- 棋譜作成時の局面編集、棋譜更新での指し手の編集、棋譜詳細での棋譜再生、各ページで共通 -->
+
 <script lang="ts">
   import { BoardPosition } from '$lib/types/BoardPosition';
   import type { KifuMove } from '$lib/types/Kifu';
-  import { PieceType, type PieceClickEvent } from '$lib/types/Piece';
+  import { PiecePlace, PieceType, type PieceClickEvent } from '$lib/types/Piece';
   import Board from './Board.svelte';
   import MoveList from './MoveList.svelte';
   import PieceBox from './PieceBox.svelte';
@@ -11,13 +13,25 @@
   import TurnIndicator from './TurnIndicator.svelte';
 
   // callbacks
-  export let onChange: (position?: string, moves?: KifuMove[]) => void;
+  export let onToggleTurn: () => void = () => {};
+  export let onRotatePiece: (row: number, col: number, isBlack: boolean) => void = (
+    row,
+    col,
+    isBlack
+  ) => {};
+  export let onMovePiece: (moving: PieceClickEvent, target: PieceClickEvent) => void = (
+    moving,
+    target
+  ) => {};
+  export let onAppendMove: (num: number, move: KifuMove) => void = (num, move) => {};
+  export let onPromote: (promote: boolean) => void = (promote) => {};
 
   // parameters
   export let mode: 'position' | 'moves' = 'position';
-  export let sfen: string | undefined;
+  export let isBlackFirst: boolean | undefined = undefined;
   export let moveList: KifuMove[] = [];
-  export let moveNumber: number = 0;
+  export let moveNumber: number = 0; // 現在の手数
+  export let sfen: string | undefined; // 現在の局面
   $: visibleMoveList = mode === 'moves';
   $: visiblePieceBox = mode === 'position';
   $: position = new BoardPosition(sfen);
@@ -70,134 +84,89 @@
   const viewBoxHeight = 2640;
 
   const handleToggleTurn = () => {
-    const newPosition = position.copy();
-    newPosition.isBlackTurn = !newPosition.isBlackTurn;
-    const newSfen = newPosition.toSfen(1); // 手数は1固定
-    onChange(newSfen, moveList);
+    if (mode === 'position') {
+      onToggleTurn();
+    }
   };
 
   const handleRightClick = (event: PieceClickEvent) => {
-    if (event.source.type !== 'board' || event.pieceType === PieceType.VACANCY) {
-      return;
-    }
-
-    const i = event.source.row;
-    const j = event.source.col;
-    const newPosition = position.copy();
-    if (event.source.isBlack) {
-      const piece = newPosition.blackBoard[i][j];
-      if (piece & PieceType.PROMOTE || piece === PieceType.KI || piece === PieceType.OU) {
-        // 先手の成駒or金or王 -> 後手の表駒
-        newPosition.whiteBoard[i][j] = piece & ~PieceType.PROMOTE;
-        newPosition.blackBoard[i][j] = PieceType.VACANCY;
-      } else {
-        // 先手の表駒 -> 先手の成駒
-        newPosition.blackBoard[i][j] = piece | PieceType.PROMOTE;
+    if (mode === 'position') {
+      if (event.source.type !== 'board' || event.pieceType === PieceType.VACANCY) {
+        return;
       }
-    } else {
-      const piece = newPosition.whiteBoard[i][j];
-      if (piece & PieceType.PROMOTE || piece === PieceType.KI || piece === PieceType.OU) {
-        // 後手の成駒or金or王 -> 先手の表駒
-        newPosition.blackBoard[i][j] = piece & ~PieceType.PROMOTE;
-        newPosition.whiteBoard[i][j] = PieceType.VACANCY;
-      } else {
-        // 後手の表駒 -> 後手の成駒
-        newPosition.whiteBoard[i][j] = piece | PieceType.PROMOTE;
-      }
+      const row = event.source.row;
+      const col = event.source.col;
+      const isBlack = event.source.isBlack || false;
+      onRotatePiece(row, col, isBlack);
     }
-
-    // 新しいSFENを生成してコールバックを実行
-    const newSfen = newPosition.toSfen(1); // 手数は1固定
-    onChange(newSfen, moveList);
   };
 
   let pickedPiece: PieceClickEvent | undefined;
   const handlePieceClick = (newPickedPiece: PieceClickEvent) => {
     if (pickedPiece === undefined) {
-      // 駒を持ちあげる
       if (newPickedPiece.pieceType !== PieceType.VACANCY) {
+        if (mode === 'moves') {
+          // movesモードでは、自分の駒以外は持ちあげられない
+          if (
+            newPickedPiece.source.type === 'box' ||
+            newPickedPiece.source.isBlack != position.isBlackTurn
+          ) {
+            return;
+          }
+        }
+
+        // 駒を持ちあげる
         pickedPiece = newPickedPiece;
       }
     } else {
-      // 駒を移動させる
       const moving = pickedPiece; // 移動中の情報
       const target = newPickedPiece; // 移動先の情報
-      pickedPiece = undefined;
+      pickedPiece = undefined; // 駒の持ちあげをリセット
 
-      // 移動元の移動先が同じならキャンセル
+      // 移動元と移動先が同じなら何もしない
       if (moving.source.type === 'board' && target.source.type === 'board') {
         if (moving.source.row === target.source.row && moving.source.col === target.source.col) {
           return;
         }
       }
-
-      const newPosition = position.copy();
-
-      // 移動先に駒がある場合、持ち駒へ
-      if (target.source.type === 'board') {
-        if (target.pieceType !== PieceType.VACANCY) {
-          const originalType = target.pieceType & ~PieceType.PROMOTE;
-          if (originalType === PieceType.OU) {
-            // targetが玉の場合は、targetは駒箱へ
-            const num = newPosition.pieceBox.get(originalType) ?? 0;
-            newPosition.pieceBox.set(originalType, num + 1);
-          } else if (moving.source.type === 'box' || moving.source.isBlack) {
-            // 移動中の駒が、駒箱からor先手の場合、targetは先手の持ち駒へ
-            const num = newPosition.blackHands.get(originalType) ?? 0;
-            newPosition.blackHands.set(originalType, num + 1);
-          } else {
-            // 移動中の駒が後手の場合、targetは後手の持ち駒へ
-            const num = newPosition.whiteHands.get(originalType) ?? 0;
-            newPosition.whiteHands.set(originalType, num + 1);
-          }
+      if (moving.source.type === 'stand' && target.source.type === 'stand') {
+        if (moving.source.isBlack === target.source.isBlack) {
+          return;
         }
       }
-
-      // 移動先に駒を配置
-      if (target.source.type === 'board') {
-        if (moving.source.type === 'box' || moving.source.isBlack) {
-          newPosition.blackBoard[target.source.row][target.source.col] = moving.pieceType;
-          newPosition.whiteBoard[target.source.row][target.source.col] = PieceType.VACANCY;
-        } else {
-          newPosition.blackBoard[target.source.row][target.source.col] = PieceType.VACANCY;
-          newPosition.whiteBoard[target.source.row][target.source.col] = moving.pieceType;
-        }
-      } else if (target.source.type === 'stand' || target.source.type === 'box') {
-        const targetContainer =
-          target.source.type === 'stand'
-            ? target.source.isBlack
-              ? newPosition.blackHands
-              : newPosition.whiteHands
-            : newPosition.pieceBox;
-        const originalType = moving.pieceType & ~PieceType.PROMOTE;
-        const num = targetContainer.get(originalType) ?? 0;
-        targetContainer.set(originalType, num + 1);
+      if (moving.source.type === 'box' && target.source.type === 'box') {
+        return;
       }
 
-      // 移動元の駒を削除
-      if (moving.source.type === 'board') {
-        newPosition.blackBoard[moving.source.row][moving.source.col] = PieceType.VACANCY;
-        newPosition.whiteBoard[moving.source.row][moving.source.col] = PieceType.VACANCY;
-      } else if (moving.source.type === 'stand' || moving.source.type === 'box') {
-        const list =
-          moving.source.type === 'stand'
-            ? moving.source.isBlack
-              ? newPosition.blackHands
-              : newPosition.whiteHands
-            : newPosition.pieceBox;
-        const num = list.get(moving.pieceType) || 0;
-        if (num > 1) {
-          list.set(moving.pieceType, num - 1);
-        } else {
-          list.delete(moving.pieceType);
-        }
+      // 駒を移動させる
+      if (mode === 'position') {
+        onMovePiece(moving, target);
+      } else if (mode === 'moves' && isLegalMove(moving, target)) {
+        const move: KifuMove = {
+          number: moveNumber + 1,
+          piece: moving.pieceType,
+          from_place: getPlaceOfEvent(moving),
+          to_place: getPlaceOfEvent(target),
+          catch_piece: target.pieceType == PieceType.VACANCY ? undefined : target.pieceType,
+        };
+        onAppendMove(moveNumber + 1, move);
       }
-
-      // 新しいSFENを生成してコールバックを実行
-      const newSfen = newPosition.toSfen(1); // 手数は1固定
-      onChange(newSfen, moveList);
     }
   };
+
+  const isLegalMove = (moving: PieceClickEvent, target: PieceClickEvent): boolean => {
+    // ToDo: 駒の動きの合法性を確認する
+    return true;
+  };
+
+  const getPlaceOfEvent = (event: PieceClickEvent): number => {
+    const place = new PiecePlace();
+    if (event.source.type === 'board') {
+      place.setRowCol(event.source.row, event.source.col);
+    }
+    return place.val;
+  };
+
   $: if (sfen) {
     pickedPiece = undefined;
     console.debug(sfen);
@@ -208,7 +177,7 @@
   <rect width="100%" height="100%" fill="#fff" />
 
   {#if visibleMoveList}
-    <MoveList x={60} y={120} {moveList} {moveNumber} />
+    <MoveList x={60} y={120} {isBlackFirst} {moveList} {moveNumber} />
   {/if}
   <g transform={`translate(${visibleMoveList ? 860 : 0}, 0)`}>
     <PieceStand

--- a/frontend/src/lib/types/Piece.ts
+++ b/frontend/src/lib/types/Piece.ts
@@ -79,31 +79,49 @@ export const PieceOrderForSFEN = [
 ];
 
 // ------------------------------------------------------------
-export const PIECE_PLACE_IN_HAND = 0xff;
+export class PiecePlace {
+  static IN_HAND = 0xff;
+  static FILE_CHARS = ['１', '２', '３', '４', '５', '６', '７', '８', '９'];
+  static RANK_CHARS = ['一', '二', '三', '四', '五', '六', '七', '八', '九'];
+  val: number;
 
-const PiecePlaceFileChars = ['１', '２', '３', '４', '５', '６', '７', '８', '９'];
-const PiecePlaceRankChars = ['一', '二', '三', '四', '五', '六', '七', '八', '九'];
+  constructor(val?: number) {
+    this.val = val === undefined ? PiecePlace.IN_HAND : val;
+  }
+  setRowCol(row: number, col: number): void {
+    this.val = (row << 4) | col;
+  }
 
-export const fileNum = (place: number): number => {
-  return 9 - (place & 0x0f);
-};
-export const rankNum = (place: number): number => {
-  return ((place & 0xf0) >> 4) + 1;
-};
-export const fileChar = (place: number): string => {
-  const n = fileNum(place);
-  if (n > 0 && n <= 9) {
-    return PiecePlaceFileChars[n - 1];
+  row(): number {
+    return (this.val & 0xf0) >> 4;
   }
-  return '';
-};
-export const rankChar = (place: number): string => {
-  const n = rankNum(place);
-  if (n > 0 && n <= 9) {
-    return PiecePlaceRankChars[n - 1];
+  col(): number {
+    return this.val & 0x0f;
   }
-  return '';
-};
+  fileNum(): number {
+    return 9 - this.col();
+  }
+  rankNum(): number {
+    return this.row() + 1;
+  }
+  fileChar(): string {
+    const n = this.fileNum();
+    if (n > 0 && n <= 9) {
+      return PiecePlace.FILE_CHARS[n - 1];
+    }
+    return '';
+  }
+  rankChar(): string {
+    const n = this.rankNum();
+    if (n > 0 && n <= 9) {
+      return PiecePlace.RANK_CHARS[n - 1];
+    }
+    return '';
+  }
+  isInHand(): boolean {
+    return this.val === PiecePlace.IN_HAND;
+  }
+}
 
 // ------------------------------------------------------------
 export type PieceClickEvent = {

--- a/frontend/src/lib/types/Piece.ts
+++ b/frontend/src/lib/types/Piece.ts
@@ -81,6 +81,30 @@ export const PieceOrderForSFEN = [
 // ------------------------------------------------------------
 export const PIECE_PLACE_IN_HAND = 0xff;
 
+const PiecePlaceFileChars = ['１', '２', '３', '４', '５', '６', '７', '８', '９'];
+const PiecePlaceRankChars = ['一', '二', '三', '四', '五', '六', '七', '八', '九'];
+
+export const fileNum = (place: number): number => {
+  return 9 - (place & 0x0f);
+};
+export const rankNum = (place: number): number => {
+  return ((place & 0xf0) >> 4) + 1;
+};
+export const fileChar = (place: number): string => {
+  const n = fileNum(place);
+  if (n > 0 && n <= 9) {
+    return PiecePlaceFileChars[n - 1];
+  }
+  return '';
+};
+export const rankChar = (place: number): string => {
+  const n = rankNum(place);
+  if (n > 0 && n <= 9) {
+    return PiecePlaceRankChars[n - 1];
+  }
+  return '';
+};
+
 // ------------------------------------------------------------
 export type PieceClickEvent = {
   pieceType: PieceType;

--- a/frontend/src/routes/kifu/edit/+page.svelte
+++ b/frontend/src/routes/kifu/edit/+page.svelte
@@ -131,7 +131,9 @@
 
   let moves: KifuMove[] = [];
 
-  const handleChangeMove = (moves: KifuMove[]) => {};
+  const handleChangeMove = (newMoves: KifuMove[]) => {
+    moves = newMoves;
+  };
 
   const updateKifuMoves = async () => {
     // ToDo:
@@ -242,8 +244,8 @@
 
       <MovesEditor
         onChange={handleChangeMove}
-        initial={kifu.initial_position}
-        moveList={kifu.moves}
+        initialSfen={kifu.initial_position}
+        moveList={moves}
       />
       <button onclick={updateKifuMoves} class="submit">棋譜の指し手を更新</button>
     {/if}

--- a/frontend/src/routes/kifu/edit/+page.svelte
+++ b/frontend/src/routes/kifu/edit/+page.svelte
@@ -1,9 +1,11 @@
+<!-- src/routes/kifu/edit/+page.svelte -->
+
 <script lang="ts">
   import { page } from '$app/stores';
   import type { KifuDetail, KifuMove } from '$lib/types/Kifu';
-  import KifuPlayer from '$lib/components/KifuPlayer.svelte';
   import { getKifu, updateKifuInfo } from '$lib/apis/kifu';
   import { account } from '$lib/stores/session';
+  import MovesEditor from '$lib/components/MovesEditor.svelte';
 
   // ----------------------------------------
   // 棋譜データの状態管理
@@ -129,6 +131,8 @@
 
   let moves: KifuMove[] = [];
 
+  const handleChangeMove = (moves: KifuMove[]) => {};
+
   const updateKifuMoves = async () => {
     // ToDo:
     console.debug('update kifu moves');
@@ -236,7 +240,11 @@
         <button type="submit" class="submit">棋譜情報を更新</button>
       </form>
 
-      <KifuPlayer {kifu} />
+      <MovesEditor
+        onChange={handleChangeMove}
+        initial={kifu.initial_position}
+        moveList={kifu.moves}
+      />
       <button onclick={updateKifuMoves} class="submit">棋譜の指し手を更新</button>
     {/if}
   </section>

--- a/frontend/src/routes/kifu/new/+page.svelte
+++ b/frontend/src/routes/kifu/new/+page.svelte
@@ -55,15 +55,16 @@
     }
   }
 
-  let currentPosition: string | undefined;
+  // 初期局面の管理
+  let sfen: string | undefined = undefined;
 
-  function handlePositionChange(position?: string) {
-    currentPosition = position;
+  function handlePositionChange(newSfen?: string) {
+    sfen = newSfen;
   }
 
   // 初期局面から作成
   async function createFromPosition() {
-    const result = await createKifu('position', undefined, currentPosition);
+    const result = await createKifu('position', undefined, sfen);
     if (result.ok && result.data) {
       const kifuID = result.data;
       goto(`/kifu/edit/?id=${kifuID}`); // 編集画面へ遷移


### PR DESCRIPTION
指し手の編集のベースを作成し、局面編集関係のコンポーネントのリファクタリングを実施。
- PositionViewのmode="move"での挙動を実装、MovesEditor.svelteで指し手の追加を実装
- PositionView.svelteでは駒の移動の発生のみ制御し、局面の書き換えはPositionEditor.svelteで実施するよう変更
- PiecePlaceをクラスに変更
- MovesEditorで現在局面を作成する際にはBoardPositionクラスのnext()を使用
