### PR TITLE
棋譜編集での成り選択、指し手の更新

### DIFF
--- a/api/service/dao/kifu_moves.go
+++ b/api/service/dao/kifu_moves.go
@@ -48,7 +48,7 @@ func InsertKifuMoves(moves []*model.KifuMove) error {
 			branch_id, number, piece,
 			from_place, to_place,
 			comment, time_spent_ms
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
 	`
 	for _, move := range moves {
 		_, err := db.Exec(

--- a/frontend/src/lib/components/PositionView/MoveList.svelte
+++ b/frontend/src/lib/components/PositionView/MoveList.svelte
@@ -54,21 +54,26 @@
     overflow-y: auto;
 
     .move-item {
-      padding: 20px 40px;
+      padding: 20px;
       display: flex;
-      gap: 40px;
+      gap: 30px;
       align-items: baseline;
-      font-size: 80px;
-      line-height: 120px;
+      font-size: 68px;
+      line-height: 100px;
+      cursor: pointer;
 
       &.current {
         background: #e0f0ff;
       }
 
       .move-number {
-        width: 140px;
+        width: 120px;
         text-align: right;
         color: #666;
+      }
+
+      &:hover {
+        background-color: #ffe0f0;
       }
     }
   }

--- a/frontend/src/lib/components/PositionView/PromoteIndicator.svelte
+++ b/frontend/src/lib/components/PositionView/PromoteIndicator.svelte
@@ -1,0 +1,40 @@
+<!-- src/lib/components/PositionView/TurnIndicator.svelte -->
+
+<script lang="ts">
+  import { PieceType } from '$lib/types/Piece';
+  import Piece from './Piece.svelte';
+
+  export let x: number;
+  export let y: number;
+  export let pieceType: PieceType;
+  export let onSelect: ((promote: boolean) => void) | undefined = undefined;
+  const style = 'pentagon';
+</script>
+
+<g transform={`translate(${x}, ${y})`}>
+  <rect width={900} height={620} rx={30} ry={30} fill="#666" />
+  <rect x={10} y={10} width={880} height={600} rx={30} ry={30} fill="#cfc" />
+
+  <text
+    x={450}
+    y={150}
+    dominant-baseline="middle"
+    text-anchor="middle"
+    fill="#333"
+    font-size="90"
+    style:font-size="90px">成りますか？</text
+  >
+
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <g transform={`translate(${150}, ${280})`}>
+    <Piece {pieceType} {style} useViewBox={false} onClick={() => onSelect && onSelect(false)} />
+  </g>
+  <g transform={`translate(${510}, ${280})`}>
+    <Piece
+      pieceType={pieceType | PieceType.PROMOTE}
+      {style}
+      useViewBox={false}
+      onClick={() => onSelect && onSelect(true)}
+    />
+  </g>
+</g>

--- a/frontend/src/lib/components/PositionView/TurnIndicator.svelte
+++ b/frontend/src/lib/components/PositionView/TurnIndicator.svelte
@@ -1,4 +1,5 @@
 <!-- src/lib/components/PositionView/TurnIndicator.svelte -->
+
 <script lang="ts">
   export let x: number;
   export let y: number;

--- a/frontend/src/routes/kifu/edit/+page.svelte
+++ b/frontend/src/routes/kifu/edit/+page.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import type { KifuDetail, KifuMove } from '$lib/types/Kifu';
-  import { getKifu, updateKifuInfo } from '$lib/apis/kifu';
+  import { getKifu, updateKifuInfo, updateKifuMoves } from '$lib/apis/kifu';
   import { account } from '$lib/stores/session';
   import MovesEditor from '$lib/components/MovesEditor.svelte';
 
@@ -135,9 +135,17 @@
     moves = newMoves;
   };
 
-  const updateKifuMoves = async () => {
-    // ToDo:
-    console.debug('update kifu moves');
+  const handleUpdateKifuMoves = async () => {
+    if (!kifuId) {
+      return;
+    }
+    const result = await updateKifuMoves(kifuId, moves);
+    if (result.ok) {
+      await fetchKifuData();
+    } else {
+      console.error('Failed to create kifu from position: ', result);
+      isError = true;
+    }
   };
 
   // ----------------------------------------
@@ -247,7 +255,7 @@
         initialSfen={kifu.initial_position}
         moveList={moves}
       />
-      <button onclick={updateKifuMoves} class="submit">棋譜の指し手を更新</button>
+      <button onclick={handleUpdateKifuMoves} class="submit">棋譜の指し手を更新</button>
     {/if}
   </section>
 </div>

--- a/frontend/src/routes/kifu/view/+page.svelte
+++ b/frontend/src/routes/kifu/view/+page.svelte
@@ -5,7 +5,6 @@
   import type { KifuDetail } from '$lib/types/Kifu';
   import { page } from '$app/stores';
   import KifuPlayer from '$lib/components/KifuPlayer.svelte';
-  import { initialPosition } from '$lib/test/positions';
   import { account } from '$lib/stores/session';
   import { getKifu } from '$lib/apis/kifu';
   import { formatDateTime, formatTimeRule } from '$lib/utils/textFormat';
@@ -128,7 +127,7 @@
         {/if}
       </form>
 
-      <KifuPlayer {kifu} />
+      <!-- <KifuPlayer {kifu} /> -->
     </section>
 
     <section class="basic">


### PR DESCRIPTION
- 棋譜編集ページにて、成り選択ができるように実装
- 不成の際に指し手の一覧表示が幅に収まるようサイズ調整
- 指し手の更新のAPIをコールするよう実装
- API側のバグを修正